### PR TITLE
feat(hearth): add Food Planner page with Notes/Recipes/Inventory tabs

### DIFF
--- a/projects/nx-workspace/apps/hearth/src/app/app.consts.ts
+++ b/projects/nx-workspace/apps/hearth/src/app/app.consts.ts
@@ -6,6 +6,7 @@ import {
   LayoutList,
   PenLine,
   MapPin,
+  ChefHat,
 } from 'lucide-react';
 import { ROUTES } from '../lib/routes';
 
@@ -41,6 +42,7 @@ export const NAV_LINKS = [
       { label: 'Household Rules', href: ROUTES.HOUSEHOLD_RULES },
     ],
   },
+  { label: 'Food Planner', href: ROUTES.FOOD_PLANNER, icon: ChefHat },
   { label: 'Find Members', href: ROUTES.LOCATOR, icon: MapPin },
   { label: 'Whiteboard', href: ROUTES.WHITEBOARD, icon: PenLine },
   { label: 'Chores', href: ROUTES.CHORES, icon: ListTodo },

--- a/projects/nx-workspace/apps/hearth/src/app/food-planner/page.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/food-planner/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { Tabs, Text } from '@radix-ui/themes';
+import { I18nProvider, useTranslation } from '../i18n';
+
+function FoodPlannerContent() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="max-w-5xl mx-auto p-6 space-y-6">
+      <Text size="6" weight="bold">
+        {t('FOOD_PLANNER.TITLE')}
+      </Text>
+
+      <Tabs.Root defaultValue="notes">
+        <Tabs.List>
+          <Tabs.Trigger value="notes">{t('FOOD_PLANNER.TABS.NOTES')}</Tabs.Trigger>
+          <Tabs.Trigger value="recipes">
+            {t('FOOD_PLANNER.TABS.RECIPES')}
+          </Tabs.Trigger>
+          <Tabs.Trigger value="inventory">
+            {t('FOOD_PLANNER.TABS.INVENTORY')}
+          </Tabs.Trigger>
+        </Tabs.List>
+
+        <div className="pt-4">
+          <Tabs.Content value="notes">
+            <Text size="2" color="gray">
+              {t('FOOD_PLANNER.PLACEHOLDER.NOTES')}
+            </Text>
+          </Tabs.Content>
+          <Tabs.Content value="recipes">
+            <Text size="2" color="gray">
+              {t('FOOD_PLANNER.PLACEHOLDER.RECIPES')}
+            </Text>
+          </Tabs.Content>
+          <Tabs.Content value="inventory">
+            <Text size="2" color="gray">
+              {t('FOOD_PLANNER.PLACEHOLDER.INVENTORY')}
+            </Text>
+          </Tabs.Content>
+        </div>
+      </Tabs.Root>
+    </div>
+  );
+}
+
+export default function FoodPlannerPage() {
+  return (
+    <I18nProvider>
+      <FoodPlannerContent />
+    </I18nProvider>
+  );
+}

--- a/projects/nx-workspace/apps/hearth/src/app/i18n/en.json
+++ b/projects/nx-workspace/apps/hearth/src/app/i18n/en.json
@@ -1,4 +1,17 @@
 {
+  "FOOD_PLANNER": {
+    "TITLE": "Food Planner",
+    "TABS": {
+      "NOTES": "Notes",
+      "RECIPES": "Recipes",
+      "INVENTORY": "Inventory"
+    },
+    "PLACEHOLDER": {
+      "NOTES": "Notes coming soon.",
+      "RECIPES": "Recipes coming soon.",
+      "INVENTORY": "Inventory coming soon."
+    }
+  },
   "LOCATOR": {
     "TITLE": "Find Members",
     "SHARE": "Share my location",

--- a/projects/nx-workspace/apps/hearth/src/lib/routes.ts
+++ b/projects/nx-workspace/apps/hearth/src/lib/routes.ts
@@ -25,6 +25,7 @@ export const ROUTES = {
   PROJECTS_DETAIL: (id: string) => `/projects/${id}`,
   MEALS: '/meals',
   MEALS_DETAIL: (id: string) => `/meals/${id}`,
+  FOOD_PLANNER: '/food-planner',
   DOCS: '/docs',
   DOCS_DETAIL: (id: string) => `/docs/${id}`,
   SETTINGS: '/settings',


### PR DESCRIPTION
Adds a placeholder Food Planner page to the sidebar with tabbed views for Notes, Recipes, and Inventory to be filled in later.