### PR TITLE
fix: Stop RabbitMQ connection-string drift + robust CI checks

### DIFF
--- a/.github/workflows/ci-health-check.yml
+++ b/.github/workflows/ci-health-check.yml
@@ -216,14 +216,19 @@ jobs:
           RMQ_USER="${USER_PASS%%:*}"
           RMQ_PASS="${USER_PASS#*:}"
           RMQ_HOST="${HOST_PORT%%:*}"
-          RMQ_IP=$(dig +short "$RMQ_HOST" | head -1)
           echo "::add-mask::$RMQ_PASS"
           echo "$RABBITMQ_CA_CERT" | base64 -d > /tmp/rabbitmq-ca.crt
-          RMQ_CODE=$(curl -s -o /tmp/mgmt.json -w '%{http_code}' --max-time 15 \
-            --cacert /tmp/rabbitmq-ca.crt \
-            --resolve "rabbitmq:15671:${RMQ_IP}" \
-            -u "${RMQ_USER}:${RMQ_PASS}" \
-            "https://rabbitmq:15671/api/overview" 2>/dev/null) || RMQ_CODE="timeout"
+          # SAN is 'rabbitmq'; --connect-to keeps SNI 'rabbitmq' while dialing
+          # the real host (DNS name or IP). Retry to tolerate transient blips.
+          for attempt in 1 2 3; do
+            RMQ_CODE=$(curl -s -o /tmp/mgmt.json -w '%{http_code}' --max-time 15 \
+              --cacert /tmp/rabbitmq-ca.crt \
+              --connect-to "rabbitmq:15671:${RMQ_HOST}:15671" \
+              -u "${RMQ_USER}:${RMQ_PASS}" \
+              "https://rabbitmq:15671/api/overview" 2>/dev/null) || RMQ_CODE="timeout"
+            [ "$RMQ_CODE" = "200" ] && break
+            [ "$attempt" -lt 3 ] && sleep 5
+          done
           if [ "$RMQ_CODE" = "200" ]; then
             VERSION=$(grep -o '"rabbitmq_version":"[^"]*"' /tmp/mgmt.json | cut -d'"' -f4)
             check "rabbitmq broker (version: $VERSION)" "ok"

--- a/.github/workflows/test-e2e-rabbitmq.yml
+++ b/.github/workflows/test-e2e-rabbitmq.yml
@@ -83,12 +83,19 @@ jobs:
           RMQ_PASS: ${{ env.RMQ_PASS }}
         run: |
           echo "$RABBITMQ_CA_CERT" | base64 -d > /tmp/rabbitmq-ca.crt
-          RMQ_IP=$(dig +short "$RMQ_HOST" | head -1)
-          STATUS=$(curl -s -o /tmp/mgmt.json -w '%{http_code}' --max-time 10 \
-            --cacert /tmp/rabbitmq-ca.crt \
-            --resolve "rabbitmq:15671:${RMQ_IP}" \
-            -u "${RMQ_USER}:${RMQ_PASS}" \
-            "https://rabbitmq:15671/api/overview")
+          # The broker cert's SAN is 'rabbitmq' (not the public host), so we
+          # connect to the real host but present/verify SNI 'rabbitmq' against
+          # the CA. --connect-to resolves the host itself, so it works whether
+          # RMQ_HOST is a DNS name or a raw IP. Retry to tolerate brief blips.
+          for attempt in 1 2 3; do
+            STATUS=$(curl -s -o /tmp/mgmt.json -w '%{http_code}' --max-time 10 \
+              --cacert /tmp/rabbitmq-ca.crt \
+              --connect-to "rabbitmq:15671:${RMQ_HOST}:15671" \
+              -u "${RMQ_USER}:${RMQ_PASS}" \
+              "https://rabbitmq:15671/api/overview") || STATUS="000"
+            [ "$STATUS" = "200" ] && break
+            [ "$attempt" -lt 3 ] && sleep 5
+          done
           echo "Management /api/overview status: $STATUS"
           if [ "$STATUS" != "200" ]; then
             echo "✗ Management UI check failed"

--- a/infrastructure/terraform/packer/scripts/rotate-rabbitmq-password.sh
+++ b/infrastructure/terraform/packer/scripts/rotate-rabbitmq-password.sh
@@ -46,7 +46,11 @@ sudo sed -i \"s/RABBITMQ_DEFAULT_PASS: .*/RABBITMQ_DEFAULT_PASS: ${NEW_PASSWORD}
 sudo docker compose -f /opt/rabbitmq/docker-compose.yml up -d
 "
 
-NEW_CONNECTION_STRING="amqps://${RABBITMQ_USER}:${NEW_PASSWORD}@${RABBITMQ_IP}:5671"
+# Connection string always uses the DNS name (RABBITMQ_IP is the SSH target,
+# which is the raw IP in local mode) so it matches the broker cert's SAN and
+# stays consistent with post-apply.sh — otherwise local rotations drift Vault
+# to the IP form and break the TLS-verifying CI checks.
+NEW_CONNECTION_STRING="amqps://${RABBITMQ_USER}:${NEW_PASSWORD}@${RABBITMQ_HOST}:5671"
 
 echo "Waiting for RabbitMQ to finish starting..."
 READY=false

--- a/infrastructure/terraform/scripts/post-apply.sh
+++ b/infrastructure/terraform/scripts/post-apply.sh
@@ -69,7 +69,12 @@ sync_secrets_to_vault() {
     return
   fi
 
-  local conn_str="amqps://${rabbitmq_user}:${rabbitmq_password}@${rabbitmq_ip}:5671"
+  # Use the DNS name (not the raw IP) so the connection string matches the
+  # broker cert's SAN and stays consistent with rotate-rabbitmq-password.sh —
+  # otherwise this sync silently flips Vault to the IP form and breaks the
+  # curl-based mgmt/health checks that verify TLS against SNI 'rabbitmq'.
+  local rabbitmq_host="socket.harryliu.dev"
+  local conn_str="amqps://${rabbitmq_user}:${rabbitmq_password}@${rabbitmq_host}:5671"
   local ca_cert_b64=$(echo "$ca_cert" | base64 -w 0)
   # Trailing newline is required — $(...) strips it, and OpenSSH/libcrypto reject a key without it.
   local ci_ssh_key_b64=$(printf '%s\n' "$ci_ssh_private_key" | base64 -w 0)


### PR DESCRIPTION
## Summary

Root cause of the `test-e2e-rabbitmq` + `ci-health-check` failures: **not a broker outage** (SSH'd to the VM — the `rabbitmq` container was `Up 20h (healthy)`, never restarted). `RABBITMQ_CONNECTION_STRING` in Vault has multiple writers that disagreed on the host, drifting the value between a **DNS name** (`socket.harryliu.dev`) and the **raw OCI IP** (`40.233.79.94`). The broker cert's SAN is only `rabbitmq` (no IP SAN), so the IP form broke the TLS-verifying curl checks, while the amqp e2e (which skips hostname verification) kept passing.

Writers, before → after:
| Writer | Before | After |
|---|---|---|
| `post-apply.sh` (`tf:apply`) | raw IP ❌ | DNS name ✅ |
| `rotate-rabbitmq-password.sh` — CI mode (`ci-rotate-secrets`) | DNS name ✅ | DNS name ✅ |
| `rotate-rabbitmq-password.sh` — local mode (`secret-rotation:rabbitmq` / local step of `secret-rotation:all`) | raw IP ❌ | DNS name ✅ |

So a `tf:apply` **or** a locally-run rotation drifted Vault to the IP form. This PR makes every writer produce the DNS-name form (the raw IP is still used as the SSH target, just not in the connection string).

Commits:
- **`fix(terraform)` — post-apply.sh** — build the connection string from `socket.harryliu.dev`, not the raw IP.
- **`fix(terraform)` — rotate-rabbitmq-password.sh** — same fix for local rotation mode.
- **`fix(github-actions)`** — replace the fragile `dig`+`--resolve` in both CI checks with `curl --connect-to`, which resolves the host itself and works for a DNS name or an IP while keeping SNI `rabbitmq` for CA verification, plus a retry loop.

## Test plan

- [x] SSH'd to the VM: `rabbitmq` container `Up 20 hours (healthy)`, started `2026-07-14T15:35:59Z`, mgmt HTTPS listener on 15671, `admin` user present — broker was up the entire time
- [x] Verified `--connect-to` returns 401 (reached + TLS-verified against CA) for **both** the `socket.harryliu.dev` and raw-IP forms
- [ ] After next `tf:apply` or rotation, Vault `RABBITMQ_CONNECTION_STRING` holds the `socket.harryliu.dev` form
- [ ] `test-e2e-rabbitmq` passes on next `deploy`/`workflow_dispatch`
- [ ] `ci-health-check` reports rabbitmq broker ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)