### PR TITLE
fix(vb-manager-next): Migrate middleware.ts to proxy.ts

### DIFF
--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/proxy.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/proxy.ts
@@ -12,7 +12,7 @@ const unauthorized = (): NextResponse =>
     { status: HTTP_STATUS_CODES.UNAUTHORIZED },
   );
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const auth = request.headers.get(AUTHORIZATION_HEADER);
   if (!auth?.startsWith(BEARER_PREFIX)) return unauthorized();
   const token = auth.slice(BEARER_PREFIX.length);


### PR DESCRIPTION
## Summary
- Renames `apps/ui/vb-manager-next/src/middleware.ts` to `proxy.ts` and the exported `middleware` function to `proxy`, matching the Next.js 16 file convention (`middleware` is deprecated in favor of `proxy`; see https://nextjs.org/docs/messages/middleware-to-proxy).
- No behavioral change — the `config`/`matcher` export and auth logic are unchanged.

## Test plan
- [ ] `pnpm nx build vb-manager-next` completes without the middleware-to-proxy deprecation warning
- [ ] Auth-gated API routes under `vb-manager-next` still return 401 for missing/invalid bearer tokens and pass through for valid ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)