### PR TITLE
ci(nx): Enable Nx Cloud remote caching across CI

### DIFF
--- a/.github/workflows/ci-pr-check.yml
+++ b/.github/workflows/ci-pr-check.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 concurrency:
   group: ci-pr-check-${{ github.ref }}
@@ -22,8 +23,23 @@ jobs:
 
       - uses: ./.github/actions/setup-nx-workspace
 
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Fetch Nx Cloud read-only token from Secret Manager
+        id: nx-cloud
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            NX_CLOUD_ACCESS_TOKEN:vigilant-broccoli/NX_CLOUD_ACCESS_TOKEN_READ_ONLY
+
       - name: Lint, test, build affected
         working-directory: ./projects/nx-workspace
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ steps.nx-cloud.outputs.NX_CLOUD_ACCESS_TOKEN }}
         run: pnpm exec nx affected -t lint test build --base=$NX_BASE --head=$NX_HEAD
 
   pre-commit:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,6 +91,13 @@ jobs:
           secrets: |
             kv/data/secrets NPM_TOKEN | NODE_AUTH_TOKEN ;
 
+      - name: Fetch Nx Cloud read-write token from Secret Manager
+        id: nx-cloud
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            NX_CLOUD_ACCESS_TOKEN:vigilant-broccoli/NX_CLOUD_ACCESS_TOKEN
+
       - name: Check if npm publish needed
         id: check
         working-directory: ./projects/nx-workspace
@@ -107,6 +114,8 @@ jobs:
       - name: Build packages
         if: steps.check.outputs.has_packages == 'true'
         working-directory: ./projects/nx-workspace
+        env:
+          NX_CLOUD_ACCESS_TOKEN: ${{ steps.nx-cloud.outputs.NX_CLOUD_ACCESS_TOKEN }}
         run: pnpm exec nx run-many -t build --projects="${{ steps.check.outputs.projects }}"
 
       - name: Publish npm packages
@@ -182,6 +191,14 @@ jobs:
             CF_ACCESS_CLIENT_ID:vigilant-broccoli/VAULT_CF_ACCESS_CLIENT_ID
             CF_ACCESS_CLIENT_SECRET:vigilant-broccoli/VAULT_CF_ACCESS_CLIENT_SECRET
 
+      - name: Fetch Nx Cloud read-write token from Secret Manager
+        id: nx-cloud
+        if: steps.check.outputs.has_deployments == 'true'
+        uses: google-github-actions/get-secretmanager-secrets@bc9c54b29fdffb8a47776820a7d26e77b379d262 # v3
+        with:
+          secrets: |-
+            NX_CLOUD_ACCESS_TOKEN:vigilant-broccoli/NX_CLOUD_ACCESS_TOKEN
+
       - name: Log in to Docker Hub
         if: steps.check.outputs.has_deployments == 'true'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
@@ -201,6 +218,7 @@ jobs:
           VAULT_ADDR: https://vault.harryliu.dev
           CF_ACCESS_CLIENT_ID: ${{ steps.cf-access.outputs.CF_ACCESS_CLIENT_ID }}
           CF_ACCESS_CLIENT_SECRET: ${{ steps.cf-access.outputs.CF_ACCESS_CLIENT_SECRET }}
+          NX_CLOUD_ACCESS_TOKEN: ${{ steps.nx-cloud.outputs.NX_CLOUD_ACCESS_TOKEN }}
         run: ${{ steps.check.outputs.deploy_cmd }}
 
   deploy-github-pages:

--- a/projects/nx-workspace/nx.json
+++ b/projects/nx-workspace/nx.json
@@ -81,7 +81,6 @@
       "inputs": ["default", "^default"]
     }
   },
-  "neverConnectToCloud": true,
   "generators": {
     "@nx/angular:application": {
       "linter": "eslint",
@@ -179,5 +178,6 @@
   "analytics": false,
   "migrate": {
     "agentic": false
-  }
+  },
+  "nxCloudId": "6a578d61269ecfeebfec0ad3"
 }


### PR DESCRIPTION
## Summary

- Connect the nested `projects/nx-workspace` to Nx Cloud (`nxCloudId`) and remove the `neverConnectToCloud` guard so CI can share a computation cache across runs and machines.
- Wire `NX_CLOUD_ACCESS_TOKEN` into the two Nx-running workflows, fetched from **GCP Secret Manager** (no new repo secrets, per CLAUDE.md policy):
  - `ci-pr-check.yml` → **read-only** token (`NX_CLOUD_ACCESS_TOKEN_READ_ONLY`) so PRs read the shared cache but can't poison it. Adds `id-token: write` for WIF.
  - `deploy.yml` → **read-write** token (`NX_CLOUD_ACCESS_TOKEN`) on the `deploy-npm-packages` build and `deploy-apps` steps so `main` populates the cache.

## Follow-up required before remote cache is active

- [ ] Create two access tokens in the Nx Cloud workspace (`nxCloudId=6a578d61269ecfeebfec0ad3`) — one read-write, one read-only.
- [ ] Store them in GCP Secret Manager as `NX_CLOUD_ACCESS_TOKEN` and `NX_CLOUD_ACCESS_TOKEN_READ_ONLY` under project `vigilant-broccoli`.
- [ ] Ensure the CI service account has `roles/secretmanager.secretAccessor` on both.

Until the secrets exist, CI falls back to local-only cache (no failure — the token env var is just empty).

## Test plan

- [x] Local computation cache verified: second `nx run @vigilant-broccoli/llm-schemas:lint` reads from cache.
- [x] `nxCloudId` present in `nx.json`; workspace connection confirmed by Nx CLI.
- [x] Both workflows validated as parseable YAML; pre-commit `check yaml` passed.
- [ ] After secrets are added: PR run shows a remote cache read; a `main` deploy run shows a remote cache write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)