### PR TITLE
fix(vb-manager-next-mobile): Copy public/ from source instead of dist in Docker build

### DIFF
--- a/projects/nx-workspace/apps/vb-manager-next-mobile/Dockerfile
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/Dockerfile
@@ -13,7 +13,7 @@ RUN addgroup --system --gid 1001 nodejs && \
 
 COPY dist/apps/vb-manager-next-mobile/.next/standalone ./
 COPY dist/apps/vb-manager-next-mobile/.next/static ./projects/nx-workspace/dist/apps/vb-manager-next-mobile/.next/static
-COPY dist/apps/vb-manager-next-mobile/public ./projects/nx-workspace/apps/vb-manager-next-mobile/public
+COPY apps/vb-manager-next-mobile/public ./projects/nx-workspace/apps/vb-manager-next-mobile/public
 
 RUN chown -R nextjs:nodejs /app
 


### PR DESCRIPTION
## Summary
- `vb-manager-next-mobile` deploys were failing at the Docker build step: `COPY dist/apps/vb-manager-next-mobile/public ...` errored with "not found".
- Root cause: the Next.js executor migration in #93 switched this app's build target from `@nx/next:build` to a plain `next build --webpack` run via `nx:run-commands`. The old executor copied `public/` into `dist/` as part of its output; the new command only produces `.next/` there, so `public/` was never populated in `dist/`.
- Fix: copy `public/` from the source tree (`apps/vb-manager-next-mobile/public`) instead of `dist/`, matching the pattern already used by `employee-handler-ui`, which was migrated the same way in the same PR and deploys fine.

## Test plan
- [ ] Confirm `vb-manager-next-mobile` staging deploy succeeds (Docker build no longer errors on the `public/` COPY step)
- [ ] Confirm the deployed app serves static assets from `public/` (e.g. favicon) correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)