### PR TITLE
fix(fastify): Fail closed in api-key plugin when key is unconfigured

### DIFF
--- a/projects/nx-workspace/libs/@vigilant-broccoli/fastify/src/plugins/api-key.plugin.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/fastify/src/plugins/api-key.plugin.ts
@@ -15,7 +15,12 @@ export const createApiKeyPlugin = (
 ) => {
   const plugin: FastifyPluginAsync = async app => {
     app.addHook('onRequest', async (req, reply) => {
-      if (!apiKey) return;
+      if (!apiKey) {
+        reply
+          .code(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR)
+          .send({ error: ERROR_UNAUTHORIZED });
+        return;
+      }
       const providedKey = req.headers[API_KEY_HEADER];
       if (verifyApiKey) {
         if (


### PR DESCRIPTION
## Summary
- `createApiKeyPlugin` previously did `if (!apiKey) return;` on the `onRequest` hook — an empty or unset API key (e.g. `getEnvironmentVariable` returning `''`) silently disabled auth entirely, making every route public.
- Now rejects all requests with a 500 when the plugin is registered but no key is configured, so a misconfigured deploy fails closed instead of silently exposing the service.

## Test plan
- [x] `nx run @vigilant-broccoli/fastify:build` passes
- [ ] Deploy a service (e.g. bucket-service) with the API key env var unset and confirm requests are rejected instead of passing through