### PR TITLE
feat(recipe-scraper): Add image input and move scraping logic to vb-express

### DIFF
--- a/projects/nx-workspace/apps/api/vb-express/src/libs/swagger.ts
+++ b/projects/nx-workspace/apps/api/vb-express/src/libs/swagger.ts
@@ -2,7 +2,7 @@ import { createSwaggerSpec } from '@vigilant-broccoli/fastify';
 
 const SERVICE_TITLE = 'vb-express';
 const SERVICE_DESCRIPTION =
-  'Personal API gateway: better-auth sessions, API key admin, Google Tasks, LLM-backed parsing (calendar, tasks, receipts, storage), messaging, and audio. /api routes require an x-api-key header with the matching service permission.';
+  'Personal API gateway: better-auth sessions, API key admin, Google Tasks, LLM-backed parsing (calendar, tasks, receipts, recipes, storage), messaging, and audio. /api routes require an x-api-key header with the matching service permission.';
 
 const JSON_CONTENT = 'application/json';
 const MULTIPART_CONTENT = 'multipart/form-data';
@@ -459,6 +459,26 @@ export const swaggerSpec = createSwaggerSpec({
           '200': { description: '{ store, purchasedAt, items }' },
           '400': { description: 'images is required' },
           '401': UNAUTHORIZED_RESPONSE,
+        },
+      },
+    },
+    '/api/recipe/scrape': {
+      post: {
+        summary: 'Extract a recipe as markdown from a URL or image(s) via LLM',
+        requestBody: jsonBody({
+          type: 'object',
+          properties: {
+            url: { type: 'string' },
+            images: imagesSchema,
+            languageCode: { type: 'string' },
+          },
+        }),
+        responses: {
+          '200': { description: '{ title, markdown }' },
+          '400': { description: 'Provide a url or at least one image' },
+          '401': UNAUTHORIZED_RESPONSE,
+          '422': { description: 'No recipe could be found' },
+          '502': { description: 'Could not reach or read the given URL' },
         },
       },
     },

--- a/projects/nx-workspace/apps/api/vb-express/src/libs/swagger.ts
+++ b/projects/nx-workspace/apps/api/vb-express/src/libs/swagger.ts
@@ -464,18 +464,22 @@ export const swaggerSpec = createSwaggerSpec({
     },
     '/api/recipe/scrape': {
       post: {
-        summary: 'Extract a recipe as markdown from a URL or image(s) via LLM',
+        summary:
+          'Extract a recipe as markdown from a URL, pasted text, or image(s) via LLM',
         requestBody: jsonBody({
           type: 'object',
           properties: {
             url: { type: 'string' },
+            text: { type: 'string' },
             images: imagesSchema,
             languageCode: { type: 'string' },
           },
         }),
         responses: {
           '200': { description: '{ title, markdown }' },
-          '400': { description: 'Provide a url or at least one image' },
+          '400': {
+            description: 'Provide a url, pasted text, or at least one image',
+          },
           '401': UNAUTHORIZED_RESPONSE,
           '422': { description: 'No recipe could be found' },
           '502': { description: 'Could not reach or read the given URL' },

--- a/projects/nx-workspace/apps/api/vb-express/src/main.ts
+++ b/projects/nx-workspace/apps/api/vb-express/src/main.ts
@@ -17,6 +17,7 @@ import speechToTextRoutes from './routes/speech-to-text';
 import textToSpeechRoutes from './routes/text-to-speech';
 import whereIsRoutes from './routes/where-is';
 import priceTrackerRoutes from './routes/price-tracker';
+import recipeRoutes from './routes/recipe';
 import { getEnvironmentVariable } from '@vigilant-broccoli/common-node';
 import { VB_EXPRESS_SERVICE } from '@vigilant-broccoli/common-js';
 import {
@@ -131,6 +132,9 @@ const buildApp = async () => {
     VB_EXPRESS_SERVICE.PRICE_TRACKER,
     [priceTrackerRoutes],
   );
+  await registerService(app, '/api/recipe', VB_EXPRESS_SERVICE.RECIPE, [
+    recipeRoutes,
+  ]);
   await app.register(
     async scope => {
       await scope.register(createApiKeyPlugin(API_KEY, verifyApiKey));

--- a/projects/nx-workspace/apps/api/vb-express/src/routes/recipe.ts
+++ b/projects/nx-workspace/apps/api/vb-express/src/routes/recipe.ts
@@ -16,12 +16,51 @@ const NO_RECIPE_FOUND = 'NO_RECIPE_FOUND';
 const MIN_CLEAN_CONTENT_LENGTH = 200;
 
 const ERROR_NO_INPUT = 'Provide a url or at least one image';
+const ERROR_URL_NOT_ALLOWED = 'This URL cannot be fetched';
 const ERROR_FETCH_FAILED = (url: string) => `Could not reach ${url}`;
 const ERROR_PAGE_NOT_OK = (res: Response) =>
   `Page returned ${res.status} ${res.statusText} - the site may be blocking automated requests`;
 const ERROR_UNREADABLE_PAGE =
   'The page could not be read as a recipe (it may be behind a bot/cookie check or blocked the request)';
 const ERROR_NO_RECIPE_FOUND = 'No recipe could be found';
+
+const ALLOWED_URL_PROTOCOLS = ['http:', 'https:'];
+const PRIVATE_HOSTNAME_SUFFIXES = ['.local', '.internal'];
+const BLOCKED_HOSTNAMES = ['localhost', 'metadata.google.internal'];
+
+const isPrivateIpv4 = (hostname: string): boolean => {
+  const parts = hostname.split('.').map(Number);
+  if (parts.length !== 4 || parts.some(part => Number.isNaN(part))) {
+    return false;
+  }
+  const [a, b] = parts;
+  const singleOctetMatch = [127, 10, 0].includes(a);
+  const linkLocalMatch = a === 169 && b === 254;
+  const class16Match = a === 172 && b >= 16 && b <= 31;
+  const class24Match = a === 192 && b === 168;
+  return singleOctetMatch || linkLocalMatch || class16Match || class24Match;
+};
+
+const isAllowedUrl = (url: string): boolean => {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+
+  if (!ALLOWED_URL_PROTOCOLS.includes(parsed.protocol)) return false;
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (BLOCKED_HOSTNAMES.includes(hostname)) return false;
+  if (PRIVATE_HOSTNAME_SUFFIXES.some(suffix => hostname.endsWith(suffix))) {
+    return false;
+  }
+  if (hostname === '[::1]' || hostname.startsWith('[fe80:')) return false;
+  if (isPrivateIpv4(hostname)) return false;
+
+  return true;
+};
 
 const BOT_CHALLENGE_MARKERS = [
   'just a moment',
@@ -64,21 +103,21 @@ const RECIPE_TEMPLATE = `# [Recipe Name]
 
 const extractCleanContent = (html: string): string =>
   html
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
+    .replace(/<script\b[^<]*(?:(?!<\/script\s*>)<[^<]*)*<\/script\s*>/gi, '')
+    .replace(/<style\b[^<]*(?:(?!<\/style\s*>)<[^<]*)*<\/style\s*>/gi, '')
     .replace(
-      /<(nav|footer|header|iframe|noscript|svg)[^>]*>[\s\S]*?<\/\1>/gi,
+      /<(nav|footer|header|iframe|noscript|svg)\b[^>]*>[\s\S]*?<\/\1\s*>/gi,
       '',
     )
     .replace(/<!--[\s\S]*?-->/g, '')
     .replace(/<[^>]+>/g, ' ')
     .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
     .replace(/&[a-z]+;/gi, ' ')
+    .replace(/&amp;/g, '&')
     .replace(/\s+/g, ' ')
     .replace(/\n\s*\n/g, '\n')
     .trim();
@@ -137,6 +176,15 @@ const scrapeUrl = async (
   content?: string;
   error?: { status: number; message: string };
 }> => {
+  if (!isAllowedUrl(url)) {
+    return {
+      error: {
+        status: HTTP_STATUS_CODES.BAD_REQUEST,
+        message: ERROR_URL_NOT_ALLOWED,
+      },
+    };
+  }
+
   let pageResponse: Response;
   try {
     pageResponse = await fetch(url);

--- a/projects/nx-workspace/apps/api/vb-express/src/routes/recipe.ts
+++ b/projects/nx-workspace/apps/api/vb-express/src/routes/recipe.ts
@@ -303,6 +303,41 @@ const scrapeUrl = async (
   return { content: cleanContent };
 };
 
+const resolveSource = async (
+  trimmedUrl: string | undefined,
+  trimmedText: string | undefined,
+): Promise<{
+  textContent?: string;
+  sourceDescription: string;
+  error?: { status: number; message: string };
+}> => {
+  if (trimmedUrl) {
+    const { content, error } = await scrapeUrl(trimmedUrl);
+    if (error) return { sourceDescription: '', error };
+    return {
+      textContent: content,
+      sourceDescription: `this text content. The original URL is: ${trimmedUrl}`,
+    };
+  }
+
+  if (trimmedText) {
+    return { textContent: trimmedText, sourceDescription: 'this text content' };
+  }
+
+  return { sourceDescription: 'the attached image(s)' };
+};
+
+const parseRecipeResponse = (
+  markdown: string,
+): { error: string } | { title: string; markdown: string } => {
+  if (markdown.trim() === NO_RECIPE_FOUND) {
+    return { error: ERROR_NO_RECIPE_FOUND };
+  }
+  const titleMatch = markdown.match(/^#\s+(.+)$/m);
+  const title = titleMatch ? titleMatch[1] : UNTITLED_RECIPE;
+  return { title, markdown };
+};
+
 const recipeRoutes: FastifyPluginAsync = async app => {
   app.post('/scrape', async (req, reply) => {
     const { url, text, images, languageCode } = req.body as ScrapeRequest;
@@ -316,21 +351,12 @@ const recipeRoutes: FastifyPluginAsync = async app => {
         .send({ error: ERROR_NO_INPUT });
     }
 
-    let textContent: string | undefined;
-    let sourceDescription: string;
-
-    if (trimmedUrl) {
-      const { content, error } = await scrapeUrl(trimmedUrl);
-      if (error) {
-        return reply.code(error.status).send({ error: error.message });
-      }
-      textContent = content;
-      sourceDescription = `this text content. The original URL is: ${trimmedUrl}`;
-    } else if (trimmedText) {
-      textContent = trimmedText;
-      sourceDescription = 'this text content';
-    } else {
-      sourceDescription = 'the attached image(s)';
+    const { textContent, sourceDescription, error } = await resolveSource(
+      trimmedUrl,
+      trimmedText,
+    );
+    if (error) {
+      return reply.code(error.status).send({ error: error.message });
     }
 
     const userPrompt = buildRecipePrompt(
@@ -345,18 +371,14 @@ const recipeRoutes: FastifyPluginAsync = async app => {
       model: LLM_MODEL.GPT_4O_MINI,
     });
 
-    const markdown = outputs[0];
-
-    if (markdown.trim() === NO_RECIPE_FOUND) {
+    const result = parseRecipeResponse(outputs[0]);
+    if ('error' in result) {
       return reply
         .code(HTTP_STATUS_CODES.UNPROCESSABLE_ENTITY)
-        .send({ error: ERROR_NO_RECIPE_FOUND });
+        .send({ error: result.error });
     }
 
-    const titleMatch = markdown.match(/^#\s+(.+)$/m);
-    const title = titleMatch ? titleMatch[1] : UNTITLED_RECIPE;
-
-    return { title, markdown };
+    return result;
   });
 };
 

--- a/projects/nx-workspace/apps/api/vb-express/src/routes/recipe.ts
+++ b/projects/nx-workspace/apps/api/vb-express/src/routes/recipe.ts
@@ -6,6 +6,7 @@ type RecipeImage = { name: string; base64: string; mimeType: string };
 
 type ScrapeRequest = {
   url?: string;
+  text?: string;
   images?: RecipeImage[];
   languageCode?: string;
 };
@@ -15,7 +16,7 @@ const UNTITLED_RECIPE = 'Untitled Recipe';
 const NO_RECIPE_FOUND = 'NO_RECIPE_FOUND';
 const MIN_CLEAN_CONTENT_LENGTH = 200;
 
-const ERROR_NO_INPUT = 'Provide a url or at least one image';
+const ERROR_NO_INPUT = 'Provide a url, pasted text, or at least one image';
 const ERROR_URL_NOT_ALLOWED = 'This URL cannot be fetched';
 const ERROR_FETCH_FAILED = (url: string) => `Could not reach ${url}`;
 const ERROR_PAGE_NOT_OK = (res: Response) =>
@@ -304,11 +305,12 @@ const scrapeUrl = async (
 
 const recipeRoutes: FastifyPluginAsync = async app => {
   app.post('/scrape', async (req, reply) => {
-    const { url, images, languageCode } = req.body as ScrapeRequest;
+    const { url, text, images, languageCode } = req.body as ScrapeRequest;
     const trimmedUrl = url?.trim();
+    const trimmedText = text?.trim();
     const hasImages = !!images && images.length > 0;
 
-    if (!trimmedUrl && !hasImages) {
+    if (!trimmedUrl && !trimmedText && !hasImages) {
       return reply
         .code(HTTP_STATUS_CODES.BAD_REQUEST)
         .send({ error: ERROR_NO_INPUT });
@@ -324,6 +326,9 @@ const recipeRoutes: FastifyPluginAsync = async app => {
       }
       textContent = content;
       sourceDescription = `this text content. The original URL is: ${trimmedUrl}`;
+    } else if (trimmedText) {
+      textContent = trimmedText;
+      sourceDescription = 'this text content';
     } else {
       sourceDescription = 'the attached image(s)';
     }

--- a/projects/nx-workspace/apps/api/vb-express/src/routes/recipe.ts
+++ b/projects/nx-workspace/apps/api/vb-express/src/routes/recipe.ts
@@ -101,26 +101,105 @@ const RECIPE_TEMPLATE = `# [Recipe Name]
 - [Link text](RECIPE_URL)
 - [Another reference, ie YouTube if applicable](VIDEO_URL)`;
 
-const extractCleanContent = (html: string): string =>
-  html
-    .replace(/<script\b[^<]*(?:(?!<\/script\s*>)<[^<]*)*<\/script\s*>/gi, '')
-    .replace(/<style\b[^<]*(?:(?!<\/style\s*>)<[^<]*)*<\/style\s*>/gi, '')
-    .replace(
-      /<(nav|footer|header|iframe|noscript|svg)\b[^>]*>[\s\S]*?<\/\1\s*>/gi,
-      '',
-    )
-    .replace(/<!--[\s\S]*?-->/g, '')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&[a-z]+;/gi, ' ')
-    .replace(/&amp;/g, '&')
+const SKIPPED_CONTENT_TAGS = new Set([
+  'script',
+  'style',
+  'nav',
+  'footer',
+  'header',
+  'iframe',
+  'noscript',
+  'svg',
+]);
+
+const HTML_ENTITIES: Record<string, string> = {
+  nbsp: ' ',
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  '#39': "'",
+  apos: "'",
+};
+
+const decodeEntity = (entity: string): string => {
+  const body = entity.slice(1, -1);
+  return HTML_ENTITIES[body.toLowerCase()] ?? ' ';
+};
+
+// Finds the index right after the next literal `</tagName ... >` sequence, searching raw
+// text (not tag-aware) since content inside script/style bodies isn't markup.
+const findCloseTagEnd = (
+  html: string,
+  tagName: string,
+  from: number,
+): number => {
+  const closer = new RegExp(`</${tagName}[^>]*>`, 'i');
+  const match = closer.exec(html.slice(from));
+  return match ? from + match.index + match[0].length : html.length;
+};
+
+// Consumes one tag starting at `i` (html[i] === '<'), returning the next scan index and
+// any text to append (a space for a normal tag, nothing for a skipped-content tag).
+const consumeTag = (
+  html: string,
+  i: number,
+): { nextIndex: number; append: string } => {
+  const tagEnd = html.indexOf('>', i);
+  if (tagEnd === -1) return { nextIndex: html.length, append: '' };
+
+  const tagContent = html.slice(i + 1, tagEnd);
+  const tagName = tagContent
+    .match(/^\/?\s*([a-z][a-z0-9]*)/i)?.[1]
+    ?.toLowerCase();
+  const isClosing = tagContent.trimStart().startsWith('/');
+
+  if (!isClosing && tagName && SKIPPED_CONTENT_TAGS.has(tagName)) {
+    return {
+      nextIndex: findCloseTagEnd(html, tagName, tagEnd + 1),
+      append: '',
+    };
+  }
+  return { nextIndex: tagEnd + 1, append: ' ' };
+};
+
+// Single left-to-right scan, not regex matching of open/close pairs, so malformed/nested markup can't defeat it.
+const extractCleanContent = (html: string): string => {
+  let output = '';
+  let i = 0;
+
+  while (i < html.length) {
+    if (html.startsWith('<!--', i)) {
+      const end = html.indexOf('-->', i + 4);
+      i = end === -1 ? html.length : end + 3;
+      continue;
+    }
+
+    if (html[i] === '<') {
+      const { nextIndex, append } = consumeTag(html, i);
+      output += append;
+      i = nextIndex;
+      continue;
+    }
+
+    if (html[i] === '&') {
+      const entityMatch = html.slice(i, i + 12).match(/^&#?[a-z0-9]+;/i);
+      if (entityMatch) {
+        output += decodeEntity(entityMatch[0]);
+        i += entityMatch[0].length;
+        continue;
+      }
+    }
+
+    output += html[i];
+    i += 1;
+  }
+
+  return output
     .replace(/\s+/g, ' ')
     .replace(/\n\s*\n/g, '\n')
     .trim();
+};
 
 const looksLikeBotChallenge = (cleanContent: string): boolean => {
   const lowerContent = cleanContent.toLowerCase();

--- a/projects/nx-workspace/apps/api/vb-express/src/routes/recipe.ts
+++ b/projects/nx-workspace/apps/api/vb-express/src/routes/recipe.ts
@@ -1,0 +1,231 @@
+import { FastifyPluginAsync } from 'fastify';
+import { LLM_MODEL, HTTP_STATUS_CODES } from '@vigilant-broccoli/common-js';
+import { callLlm } from '../libs/llm-service.client';
+
+type RecipeImage = { name: string; base64: string; mimeType: string };
+
+type ScrapeRequest = {
+  url?: string;
+  images?: RecipeImage[];
+  languageCode?: string;
+};
+
+const DEFAULT_LANGUAGE_CODE = 'en-US';
+const UNTITLED_RECIPE = 'Untitled Recipe';
+const NO_RECIPE_FOUND = 'NO_RECIPE_FOUND';
+const MIN_CLEAN_CONTENT_LENGTH = 200;
+
+const ERROR_NO_INPUT = 'Provide a url or at least one image';
+const ERROR_FETCH_FAILED = (url: string) => `Could not reach ${url}`;
+const ERROR_PAGE_NOT_OK = (res: Response) =>
+  `Page returned ${res.status} ${res.statusText} - the site may be blocking automated requests`;
+const ERROR_UNREADABLE_PAGE =
+  'The page could not be read as a recipe (it may be behind a bot/cookie check or blocked the request)';
+const ERROR_NO_RECIPE_FOUND = 'No recipe could be found';
+
+const BOT_CHALLENGE_MARKERS = [
+  'just a moment',
+  'enable javascript and cookies to continue',
+  'checking if the site connection is secure',
+  'attention required! | cloudflare',
+  'verify you are human',
+  'access denied',
+];
+
+const RECIPE_TEMPLATE = `# [Recipe Name]
+
+## Ingredients
+
+- [Main ingredient category] (optional grouping)
+  - [Ingredient with quantity]
+  - [Ingredient with quantity]
+- [Another ingredient category] (optional grouping)
+  - [Ingredient with quantity]
+  - [Ingredient with quantity]
+- [Individual ingredients without grouping]
+
+[Garnish/Finishing section if applicable]:
+
+- [Garnish item]
+- [Garnish item]
+
+## Instructions
+
+- [Step 1]
+- [Step 2]
+- [Step 3]
+- [Continue with each step as a bullet point]
+- [Final step]
+
+## References
+
+- [Link text](RECIPE_URL)
+- [Another reference, ie YouTube if applicable](VIDEO_URL)`;
+
+const extractCleanContent = (html: string): string =>
+  html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
+    .replace(
+      /<(nav|footer|header|iframe|noscript|svg)[^>]*>[\s\S]*?<\/\1>/gi,
+      '',
+    )
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&[a-z]+;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/\n\s*\n/g, '\n')
+    .trim();
+
+const looksLikeBotChallenge = (cleanContent: string): boolean => {
+  const lowerContent = cleanContent.toLowerCase();
+  return BOT_CHALLENGE_MARKERS.some(marker => lowerContent.includes(marker));
+};
+
+const buildRecipePrompt = (
+  sourceDescription: string,
+  languageCode: string,
+  textContent?: string,
+) => `
+You are a recipe extraction assistant. Your job is to extract recipe information from the provided content and format it into clean, structured markdown.
+
+The markdown should follow this exact template format:
+${RECIPE_TEMPLATE}
+
+Important guidelines:
+- Only use ingredients, quantities, and steps that literally appear in the provided content. Never invent, guess, "improve," or add ingredients/steps/references that are not present, even if they are common for this type of dish.
+- If the content is empty, garbled, a bot/cookie/JavaScript challenge page, an error page, or otherwise does not contain an actual recipe, respond with exactly the text ${NO_RECIPE_FOUND} and nothing else.
+- Only include a reference link (e.g. a YouTube video) in the References section if its URL literally appears in the content — never fabricate one.
+- Prefer metric units over imperial units
+- Please convert all volume measurements to the following:
+  - **tsp** - teaspoon
+  - **tbsp** - tablespoon
+  - **ml** - milliliter
+  - **mg** - milligram
+- Please convert all weight measurements to the following:
+  - **g** - gram
+  - **kg** - kilogram
+- Please convert all temperature measurements to the following:
+  - **°C** - Celsius
+- Please write units together with number, ie 25g, 30ml, etc..
+- Use **bold text** for important steps or ingredients
+  - Example: **at room temperature or in the fridge**
+- Group ingredients by section if the recipe has them (e.g., "Tofu", "Sauce", "Marinade")
+- Include a separate garnish/finishing section if the recipe has garnishes or finishing touches
+- Output the recipe in the language specified by the language code: ${languageCode}
+- Return ONLY the markdown content, no additional commentary
+- Make the instructions list concise and not verbose.
+
+Extract the recipe from ${sourceDescription}.${
+  textContent
+    ? `
+
+Text Content:
+${textContent}`
+    : ''
+}`;
+
+const scrapeUrl = async (
+  url: string,
+): Promise<{
+  content?: string;
+  error?: { status: number; message: string };
+}> => {
+  let pageResponse: Response;
+  try {
+    pageResponse = await fetch(url);
+  } catch {
+    return {
+      error: {
+        status: HTTP_STATUS_CODES.BAD_GATEWAY,
+        message: ERROR_FETCH_FAILED(url),
+      },
+    };
+  }
+
+  if (!pageResponse.ok) {
+    return {
+      error: {
+        status: HTTP_STATUS_CODES.BAD_GATEWAY,
+        message: ERROR_PAGE_NOT_OK(pageResponse),
+      },
+    };
+  }
+
+  const cleanContent = extractCleanContent(await pageResponse.text());
+
+  if (
+    cleanContent.length < MIN_CLEAN_CONTENT_LENGTH ||
+    looksLikeBotChallenge(cleanContent)
+  ) {
+    return {
+      error: {
+        status: HTTP_STATUS_CODES.BAD_GATEWAY,
+        message: ERROR_UNREADABLE_PAGE,
+      },
+    };
+  }
+
+  return { content: cleanContent };
+};
+
+const recipeRoutes: FastifyPluginAsync = async app => {
+  app.post('/scrape', async (req, reply) => {
+    const { url, images, languageCode } = req.body as ScrapeRequest;
+    const trimmedUrl = url?.trim();
+    const hasImages = !!images && images.length > 0;
+
+    if (!trimmedUrl && !hasImages) {
+      return reply
+        .code(HTTP_STATUS_CODES.BAD_REQUEST)
+        .send({ error: ERROR_NO_INPUT });
+    }
+
+    let textContent: string | undefined;
+    let sourceDescription: string;
+
+    if (trimmedUrl) {
+      const { content, error } = await scrapeUrl(trimmedUrl);
+      if (error) {
+        return reply.code(error.status).send({ error: error.message });
+      }
+      textContent = content;
+      sourceDescription = `this text content. The original URL is: ${trimmedUrl}`;
+    } else {
+      sourceDescription = 'the attached image(s)';
+    }
+
+    const userPrompt = buildRecipePrompt(
+      sourceDescription,
+      languageCode ?? DEFAULT_LANGUAGE_CODE,
+      textContent,
+    );
+
+    const { outputs } = await callLlm<{ outputs: string[] }>({
+      userPrompt,
+      images,
+      model: LLM_MODEL.GPT_4O_MINI,
+    });
+
+    const markdown = outputs[0];
+
+    if (markdown.trim() === NO_RECIPE_FOUND) {
+      return reply
+        .code(HTTP_STATUS_CODES.UNPROCESSABLE_ENTITY)
+        .send({ error: ERROR_NO_RECIPE_FOUND });
+    }
+
+    const titleMatch = markdown.match(/^#\s+(.+)$/m);
+    const title = titleMatch ? titleMatch[1] : UNTITLED_RECIPE;
+
+    return { title, markdown };
+  });
+};
+
+export default recipeRoutes;

--- a/projects/nx-workspace/apps/ui/vb-manager-next/project.json
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/project.json
@@ -19,7 +19,10 @@
         "default",
         "^default",
         { "externalDependencies": ["next"] },
-        { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true }
+        { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true },
+        { "env": "NEXT_PUBLIC_SUPABASE_URL" },
+        { "env": "NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY" },
+        { "env": "NEXT_PUBLIC_SOCKET_SERVER_URL" }
       ],
       "outputs": [
         "{workspaceRoot}/dist/apps/ui/vb-manager-next/.next/!(cache)/**/*",

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/api/recipe/scrape-preview/route.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/api/recipe/scrape-preview/route.ts
@@ -1,0 +1,26 @@
+import { getVbExpressApiKey } from '../../../../lib/vb-express';
+import { NextRequest, NextResponse } from 'next/server';
+import { VB_EXPRESS_ENDPOINT } from '@vigilant-broccoli/common-js';
+import { getEnvironmentVariable } from '@vigilant-broccoli/common-node';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const body = await request.text();
+
+  const res = await fetch(
+    `${getEnvironmentVariable('VB_EXPRESS_URL')}/${VB_EXPRESS_ENDPOINT.RECIPE_SCRAPE}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': getVbExpressApiKey(),
+      },
+      body,
+    },
+  );
+
+  const data = await res.json().catch(() => ({ error: 'Invalid response' }));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/api/recipe/scrape/route.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/api/recipe/scrape/route.ts
@@ -12,8 +12,16 @@ import {
 } from '@vigilant-broccoli/common-js';
 import { VIGILANT_BROCCOLI_ROOT_PATH } from '../../../app.const';
 
+type RecipeImage = { name: string; base64: string; mimeType: string };
+
+type ScrapeRequestBody = {
+  url?: string;
+  text?: string;
+  images?: RecipeImage[];
+};
+
 export async function POST(request: NextRequest) {
-  const { url } = await request.json();
+  const { url, text, images } = (await request.json()) as ScrapeRequestBody;
 
   const res = await fetch(
     `${getEnvironmentVariable('VB_EXPRESS_URL')}/${VB_EXPRESS_ENDPOINT.RECIPE_SCRAPE}`,
@@ -23,7 +31,7 @@ export async function POST(request: NextRequest) {
         'Content-Type': 'application/json',
         'x-api-key': getVbExpressApiKey(),
       },
-      body: JSON.stringify({ url }),
+      body: JSON.stringify({ url, text, images }),
     },
   );
 

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/api/recipe/scrape/route.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/api/recipe/scrape/route.ts
@@ -1,180 +1,44 @@
+import { getVbExpressApiKey } from '../../../../lib/vb-express';
 import { NextRequest, NextResponse } from 'next/server';
-import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { writeFileSync, mkdirSync } from 'fs';
 import { resolve } from 'path';
 import { homedir } from 'os';
 import { open } from '@vigilant-broccoli/common-node';
+import { getEnvironmentVariable } from '@vigilant-broccoli/common-node';
 import {
-  API_KEY_HEADER,
-  CONTENT_TYPE_HEADER,
-  HTTP_METHOD,
   HTTP_STATUS_CODES,
-  JSON_CONTENT_TYPE,
-  LLM_MODEL,
   OPEN_TYPE,
+  VB_EXPRESS_ENDPOINT,
 } from '@vigilant-broccoli/common-js';
 import { VIGILANT_BROCCOLI_ROOT_PATH } from '../../../app.const';
 
-const LLM_SERVICE_URL = process.env['LLM_SERVICE_URL'];
-const SHARED_APP_TOKEN = process.env['SHARED_APP_TOKEN'];
-const LLM_ENDPOINT = `${LLM_SERVICE_URL}/api/llm`;
-const DEFAULT_LANGUAGE_CODE = 'en-US';
-const UNTITLED_RECIPE = 'Untitled Recipe';
-const NO_RECIPE_FOUND = 'NO_RECIPE_FOUND';
-const MIN_CLEAN_CONTENT_LENGTH = 200;
-const BOT_CHALLENGE_MARKERS = [
-  'just a moment',
-  'enable javascript and cookies to continue',
-  'checking if the site connection is secure',
-  'attention required! | cloudflare',
-  'verify you are human',
-  'access denied',
-];
-
-const extractCleanContent = (html: string): string =>
-  html
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-    .replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '')
-    .replace(
-      /<(nav|footer|header|iframe|noscript|svg)[^>]*>[\s\S]*?<\/\1>/gi,
-      '',
-    )
-    .replace(/<!--[\s\S]*?-->/g, '')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&[a-z]+;/gi, ' ')
-    .replace(/\s+/g, ' ')
-    .replace(/\n\s*\n/g, '\n')
-    .trim();
-
-const looksLikeBotChallenge = (cleanContent: string): boolean => {
-  const lowerContent = cleanContent.toLowerCase();
-  return BOT_CHALLENGE_MARKERS.some(marker => lowerContent.includes(marker));
-};
-
-const buildRecipePrompt = (
-  url: string,
-  recipeTemplate: string,
-  cleanContent: string,
-  languageCode: string,
-) => `
-You are a recipe extraction assistant. Your job is to extract recipe information from text content and format it into clean, structured markdown.
-
-The markdown should follow this exact template format:
-${recipeTemplate}
-
-Important guidelines:
-- Only use ingredients, quantities, and steps that literally appear in the Text Content below. Never invent, guess, "improve," or add ingredients/steps/references that are not present in the text, even if they are common for this type of dish.
-- If the Text Content is empty, garbled, a bot/cookie/JavaScript challenge page, an error page, or otherwise does not contain an actual recipe, respond with exactly the text ${NO_RECIPE_FOUND} and nothing else.
-- Only include a reference link (e.g. a YouTube video) in the References section if its URL literally appears in the Text Content — never fabricate one.
-- Prefer metric units over imperial units
-- Please convert all volume measurements to the following:
-  - **tsp** - teaspoon
-  - **tbsp** - tablespoon
-  - **ml** - milliliter
-  - **mg** - milligram
-- Please convert all weight measurements to the following:
-  - **g** - gram
-  - **kg** - kilogram
-- Please convert all temperature measurements to the following:
-  - **°C** - Celsius
-- Please write units together with number, ie 25g, 30ml, etc..
-- Use **bold text** for important steps or ingredients
-  - Example: **at room temperature or in the fridge**
-- Group ingredients by section if the recipe has them (e.g., "Tofu", "Sauce", "Marinade")
-- Include a separate garnish/finishing section if the recipe has garnishes or finishing touches
-- Output the recipe in the language specified by the language code: ${languageCode}
-- Return ONLY the markdown content, no additional commentary
-- Make the instructions list concise and not verbose.
-
-Extract the recipe from this text content and format it as markdown. The original URL is: ${url}
-
-Text Content:
-${cleanContent}`;
-
 export async function POST(request: NextRequest) {
   const { url } = await request.json();
+
+  const res = await fetch(
+    `${getEnvironmentVariable('VB_EXPRESS_URL')}/${VB_EXPRESS_ENDPOINT.RECIPE_SCRAPE}`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': getVbExpressApiKey(),
+      },
+      body: JSON.stringify({ url }),
+    },
+  );
+
+  const data = await res.json().catch(() => ({ error: 'Invalid response' }));
+
+  if (!res.ok) {
+    return NextResponse.json(data, { status: res.status });
+  }
+
+  const { title, markdown } = data as { title: string; markdown: string };
+
   const vbRootPath = VIGILANT_BROCCOLI_ROOT_PATH.replace(
     /^~(?=$|\/|\\)/,
     homedir(),
   );
-  const recipeTemplate = readFileSync(
-    resolve(vbRootPath, 'notes/hobbies/cooking/recipe-template.md'),
-    'utf-8',
-  );
-
-  let pageResponse: Response;
-  try {
-    pageResponse = await fetch(url);
-  } catch {
-    return NextResponse.json(
-      { error: `Could not reach ${url}` },
-      { status: HTTP_STATUS_CODES.BAD_GATEWAY },
-    );
-  }
-
-  if (!pageResponse.ok) {
-    return NextResponse.json(
-      {
-        error: `Page returned ${pageResponse.status} ${pageResponse.statusText} - the site may be blocking automated requests`,
-      },
-      { status: HTTP_STATUS_CODES.BAD_GATEWAY },
-    );
-  }
-
-  const cleanContent = extractCleanContent(await pageResponse.text());
-
-  if (
-    cleanContent.length < MIN_CLEAN_CONTENT_LENGTH ||
-    looksLikeBotChallenge(cleanContent)
-  ) {
-    return NextResponse.json(
-      {
-        error:
-          'The page could not be read as a recipe (it may be behind a bot/cookie check or blocked the request)',
-      },
-      { status: HTTP_STATUS_CODES.BAD_GATEWAY },
-    );
-  }
-
-  const llmResponse = await fetch(LLM_ENDPOINT, {
-    method: HTTP_METHOD.POST,
-    headers: {
-      [CONTENT_TYPE_HEADER]: JSON_CONTENT_TYPE,
-      [API_KEY_HEADER]: SHARED_APP_TOKEN ?? '',
-    },
-    body: JSON.stringify({
-      userPrompt: buildRecipePrompt(
-        url,
-        recipeTemplate,
-        cleanContent,
-        DEFAULT_LANGUAGE_CODE,
-      ),
-      model: LLM_MODEL.GPT_4O_MINI,
-    }),
-  });
-
-  if (!llmResponse.ok) {
-    const text = await llmResponse.text();
-    throw new Error(`llm-service ${llmResponse.status}: ${text}`);
-  }
-
-  const { outputs } = (await llmResponse.json()) as { outputs: string[] };
-  const markdown = outputs[0];
-
-  if (markdown.trim() === NO_RECIPE_FOUND) {
-    return NextResponse.json(
-      { error: 'No recipe could be found on that page' },
-      { status: HTTP_STATUS_CODES.UNPROCESSABLE_ENTITY },
-    );
-  }
-
-  const titleMatch = markdown.match(/^#\s+(.+)$/m);
-  const title = titleMatch ? titleMatch[1] : UNTITLED_RECIPE;
 
   const safeFilename =
     title
@@ -198,6 +62,6 @@ export async function POST(request: NextRequest) {
       message: 'Recipe saved successfully',
       filename: safeFilename,
     },
-    { status: 200 },
+    { status: HTTP_STATUS_CODES.OK },
   );
 }

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/llm/RecipeScraperDemo.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/llm/RecipeScraperDemo.tsx
@@ -1,0 +1,138 @@
+'use client';
+import { HTTP_METHOD, HTTP_HEADERS } from '@vigilant-broccoli/common-js';
+import { Text } from '@radix-ui/themes';
+import { Button, CopyPastable, Input } from '@vigilant-broccoli/react-lib';
+import { useState } from 'react';
+import { API_ENDPOINTS } from '../../constants/api-endpoints';
+import { authFetch } from '../../../../libs/auth';
+
+type UploadedImage = {
+  name: string;
+  base64: string;
+  mimeType: string;
+};
+
+const readImageAsBase64 = (file: File): Promise<UploadedImage> =>
+  new Promise(resolve => {
+    const reader = new FileReader();
+    reader.onload = e => {
+      const dataUrl = e.target?.result as string;
+      resolve({
+        name: file.name,
+        base64: dataUrl.split(',')[1],
+        mimeType: file.type,
+      });
+    };
+    reader.readAsDataURL(file);
+  });
+
+export const RecipeScraperDemo = () => {
+  const [recipeUrl, setRecipeUrl] = useState('');
+  const [image, setImage] = useState<UploadedImage | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{
+    title: string;
+    markdown: string;
+  } | null>(null);
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImage(await readImageAsBase64(file));
+    setRecipeUrl('');
+  };
+
+  const clearImage = () => setImage(null);
+
+  const handleScrapeRecipe = async () => {
+    if (!recipeUrl.trim() && !image) {
+      setError('Enter a URL or select an image');
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    const response = await authFetch(API_ENDPOINTS.RECIPE_SCRAPE_PREVIEW, {
+      method: HTTP_METHOD.POST,
+      headers: {
+        ...HTTP_HEADERS.CONTENT_TYPE.JSON,
+      },
+      body: JSON.stringify(image ? { images: [image] } : { url: recipeUrl }),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      setError(data.error || 'Failed to scrape recipe');
+      setLoading(false);
+      return;
+    }
+
+    setResult(data);
+    setLoading(false);
+  };
+
+  const handleRecipeKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !loading) {
+      handleScrapeRecipe();
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex gap-2 items-end">
+        <Input
+          placeholder="Enter recipe URL..."
+          value={recipeUrl}
+          onChange={e => setRecipeUrl(e.target.value)}
+          onKeyDown={handleRecipeKeyDown}
+          disabled={loading || !!image}
+          className="flex-1"
+        />
+        <Button
+          onClick={handleScrapeRecipe}
+          disabled={loading || (!recipeUrl.trim() && !image)}
+        >
+          {loading ? 'Scraping...' : 'Scrape'}
+        </Button>
+      </div>
+
+      <div className="flex gap-2 items-center">
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleFileSelect}
+          disabled={loading || !!recipeUrl.trim()}
+        />
+        {image && (
+          <>
+            <Text size="2" color="gray">
+              {image.name}
+            </Text>
+            <Button onClick={clearImage} disabled={loading} variant="outline">
+              Clear
+            </Button>
+          </>
+        )}
+      </div>
+
+      {error && (
+        <Text size="2" color="red">
+          {error}
+        </Text>
+      )}
+
+      {result && (
+        <div className="flex flex-col gap-2">
+          <Text size="3" weight="medium">
+            {result.title}
+          </Text>
+          <CopyPastable text={result.markdown} isScrollable />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/llm/RecipeScraperDemo.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/llm/RecipeScraperDemo.tsx
@@ -10,26 +10,10 @@ import {
 import { useState } from 'react';
 import { API_ENDPOINTS } from '../../constants/api-endpoints';
 import { authFetch } from '../../../../libs/auth';
-
-type UploadedImage = {
-  name: string;
-  base64: string;
-  mimeType: string;
-};
-
-const readImageAsBase64 = (file: File): Promise<UploadedImage> =>
-  new Promise(resolve => {
-    const reader = new FileReader();
-    reader.onload = e => {
-      const dataUrl = e.target?.result as string;
-      resolve({
-        name: file.name,
-        base64: dataUrl.split(',')[1],
-        mimeType: file.type,
-      });
-    };
-    reader.readAsDataURL(file);
-  });
+import {
+  UploadedImage,
+  readImageAsBase64,
+} from '../../utils/image-upload.utils';
 
 const buildScrapeRequestBody = (
   recipeUrl: string,
@@ -117,19 +101,13 @@ export const RecipeScraperDemo = () => {
 
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex gap-2 items-end">
-        <Input
-          placeholder="Enter recipe URL..."
-          value={recipeUrl}
-          onChange={handleUrlChange}
-          onKeyDown={handleRecipeKeyDown}
-          disabled={loading || hasImage || hasText}
-          className="flex-1"
-        />
-        <Button onClick={handleScrapeRecipe} disabled={loading || !hasAnyInput}>
-          {loading ? 'Scraping...' : 'Scrape'}
-        </Button>
-      </div>
+      <Input
+        placeholder="Enter recipe URL..."
+        value={recipeUrl}
+        onChange={handleUrlChange}
+        onKeyDown={handleRecipeKeyDown}
+        disabled={loading || hasImage || hasText}
+      />
 
       <Textarea
         placeholder="...or paste recipe text here"
@@ -157,6 +135,14 @@ export const RecipeScraperDemo = () => {
           </>
         )}
       </div>
+
+      <Button
+        onClick={handleScrapeRecipe}
+        disabled={loading || !hasAnyInput}
+        className="self-end"
+      >
+        {loading ? 'Scraping...' : 'Scrape'}
+      </Button>
 
       {error && (
         <Text size="2" color="red">

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/llm/RecipeScraperDemo.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/llm/RecipeScraperDemo.tsx
@@ -1,34 +1,15 @@
 'use client';
 import { HTTP_METHOD, HTTP_HEADERS } from '@vigilant-broccoli/common-js';
 import { Text } from '@radix-ui/themes';
-import {
-  Button,
-  CopyPastable,
-  Input,
-  Textarea,
-} from '@vigilant-broccoli/react-lib';
+import { Button, CopyPastable } from '@vigilant-broccoli/react-lib';
 import { useState } from 'react';
 import { API_ENDPOINTS } from '../../constants/api-endpoints';
 import { authFetch } from '../../../../libs/auth';
-import {
-  UploadedImage,
-  readImageAsBase64,
-} from '../../utils/image-upload.utils';
-
-const buildScrapeRequestBody = (
-  recipeUrl: string,
-  recipeText: string,
-  image: UploadedImage | null,
-) => {
-  if (image) return { images: [image] };
-  if (recipeText.trim()) return { text: recipeText };
-  return { url: recipeUrl };
-};
+import { useRecipeScraperInputs } from '../../hooks/useRecipeScraperInputs';
+import { RecipeScraperInputs } from './RecipeScraperInputs';
 
 export const RecipeScraperDemo = () => {
-  const [recipeUrl, setRecipeUrl] = useState('');
-  const [recipeText, setRecipeText] = useState('');
-  const [image, setImage] = useState<UploadedImage | null>(null);
+  const inputs = useRecipeScraperInputs();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [result, setResult] = useState<{
@@ -36,28 +17,8 @@ export const RecipeScraperDemo = () => {
     markdown: string;
   } | null>(null);
 
-  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setImage(await readImageAsBase64(file));
-    setRecipeUrl('');
-    setRecipeText('');
-  };
-
-  const clearImage = () => setImage(null);
-
-  const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setRecipeUrl(e.target.value);
-    if (e.target.value) setRecipeText('');
-  };
-
-  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setRecipeText(e.target.value);
-    if (e.target.value) setRecipeUrl('');
-  };
-
   const handleScrapeRecipe = async () => {
-    if (!recipeUrl.trim() && !recipeText.trim() && !image) {
+    if (!inputs.hasAnyInput) {
       setError('Enter a URL, paste recipe text, or select an image');
       return;
     }
@@ -71,9 +32,7 @@ export const RecipeScraperDemo = () => {
       headers: {
         ...HTTP_HEADERS.CONTENT_TYPE.JSON,
       },
-      body: JSON.stringify(
-        buildScrapeRequestBody(recipeUrl, recipeText, image),
-      ),
+      body: JSON.stringify(inputs.requestBody),
     });
 
     const data = await response.json();
@@ -94,51 +53,17 @@ export const RecipeScraperDemo = () => {
     }
   };
 
-  const hasUrl = !!recipeUrl.trim();
-  const hasText = !!recipeText.trim();
-  const hasImage = !!image;
-  const hasAnyInput = hasUrl || hasText || hasImage;
-
   return (
     <div className="flex flex-col gap-3">
-      <Input
-        placeholder="Enter recipe URL..."
-        value={recipeUrl}
-        onChange={handleUrlChange}
-        onKeyDown={handleRecipeKeyDown}
-        disabled={loading || hasImage || hasText}
+      <RecipeScraperInputs
+        inputs={inputs}
+        loading={loading}
+        onUrlKeyDown={handleRecipeKeyDown}
       />
-
-      <Textarea
-        placeholder="...or paste recipe text here"
-        value={recipeText}
-        onChange={handleTextChange}
-        disabled={loading || hasImage || hasUrl}
-        rows={6}
-      />
-
-      <div className="flex gap-2 items-center">
-        <input
-          type="file"
-          accept="image/*"
-          onChange={handleFileSelect}
-          disabled={loading || hasUrl || hasText}
-        />
-        {image && (
-          <>
-            <Text size="2" color="gray">
-              {image.name}
-            </Text>
-            <Button onClick={clearImage} disabled={loading} variant="outline">
-              Clear
-            </Button>
-          </>
-        )}
-      </div>
 
       <Button
         onClick={handleScrapeRecipe}
-        disabled={loading || !hasAnyInput}
+        disabled={loading || !inputs.hasAnyInput}
         className="self-end"
       >
         {loading ? 'Scraping...' : 'Scrape'}

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/llm/RecipeScraperDemo.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/llm/RecipeScraperDemo.tsx
@@ -1,7 +1,12 @@
 'use client';
 import { HTTP_METHOD, HTTP_HEADERS } from '@vigilant-broccoli/common-js';
 import { Text } from '@radix-ui/themes';
-import { Button, CopyPastable, Input } from '@vigilant-broccoli/react-lib';
+import {
+  Button,
+  CopyPastable,
+  Input,
+  Textarea,
+} from '@vigilant-broccoli/react-lib';
 import { useState } from 'react';
 import { API_ENDPOINTS } from '../../constants/api-endpoints';
 import { authFetch } from '../../../../libs/auth';
@@ -26,8 +31,19 @@ const readImageAsBase64 = (file: File): Promise<UploadedImage> =>
     reader.readAsDataURL(file);
   });
 
+const buildScrapeRequestBody = (
+  recipeUrl: string,
+  recipeText: string,
+  image: UploadedImage | null,
+) => {
+  if (image) return { images: [image] };
+  if (recipeText.trim()) return { text: recipeText };
+  return { url: recipeUrl };
+};
+
 export const RecipeScraperDemo = () => {
   const [recipeUrl, setRecipeUrl] = useState('');
+  const [recipeText, setRecipeText] = useState('');
   const [image, setImage] = useState<UploadedImage | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -41,13 +57,24 @@ export const RecipeScraperDemo = () => {
     if (!file) return;
     setImage(await readImageAsBase64(file));
     setRecipeUrl('');
+    setRecipeText('');
   };
 
   const clearImage = () => setImage(null);
 
+  const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRecipeUrl(e.target.value);
+    if (e.target.value) setRecipeText('');
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setRecipeText(e.target.value);
+    if (e.target.value) setRecipeUrl('');
+  };
+
   const handleScrapeRecipe = async () => {
-    if (!recipeUrl.trim() && !image) {
-      setError('Enter a URL or select an image');
+    if (!recipeUrl.trim() && !recipeText.trim() && !image) {
+      setError('Enter a URL, paste recipe text, or select an image');
       return;
     }
 
@@ -60,7 +87,9 @@ export const RecipeScraperDemo = () => {
       headers: {
         ...HTTP_HEADERS.CONTENT_TYPE.JSON,
       },
-      body: JSON.stringify(image ? { images: [image] } : { url: recipeUrl }),
+      body: JSON.stringify(
+        buildScrapeRequestBody(recipeUrl, recipeText, image),
+      ),
     });
 
     const data = await response.json();
@@ -81,31 +110,41 @@ export const RecipeScraperDemo = () => {
     }
   };
 
+  const hasUrl = !!recipeUrl.trim();
+  const hasText = !!recipeText.trim();
+  const hasImage = !!image;
+  const hasAnyInput = hasUrl || hasText || hasImage;
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex gap-2 items-end">
         <Input
           placeholder="Enter recipe URL..."
           value={recipeUrl}
-          onChange={e => setRecipeUrl(e.target.value)}
+          onChange={handleUrlChange}
           onKeyDown={handleRecipeKeyDown}
-          disabled={loading || !!image}
+          disabled={loading || hasImage || hasText}
           className="flex-1"
         />
-        <Button
-          onClick={handleScrapeRecipe}
-          disabled={loading || (!recipeUrl.trim() && !image)}
-        >
+        <Button onClick={handleScrapeRecipe} disabled={loading || !hasAnyInput}>
           {loading ? 'Scraping...' : 'Scrape'}
         </Button>
       </div>
+
+      <Textarea
+        placeholder="...or paste recipe text here"
+        value={recipeText}
+        onChange={handleTextChange}
+        disabled={loading || hasImage || hasUrl}
+        rows={6}
+      />
 
       <div className="flex gap-2 items-center">
         <input
           type="file"
           accept="image/*"
           onChange={handleFileSelect}
-          disabled={loading || !!recipeUrl.trim()}
+          disabled={loading || hasUrl || hasText}
         />
         {image && (
           <>

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/llm/RecipeScraperInputs.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/llm/RecipeScraperInputs.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { Text } from '@radix-ui/themes';
+import { Button, Input, Textarea } from '@vigilant-broccoli/react-lib';
+import { useRecipeScraperInputs } from '../../hooks/useRecipeScraperInputs';
+
+type RecipeScraperInputsProps = {
+  inputs: ReturnType<typeof useRecipeScraperInputs>;
+  loading: boolean;
+  onUrlKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+};
+
+export const RecipeScraperInputs = ({
+  inputs,
+  loading,
+  onUrlKeyDown,
+}: RecipeScraperInputsProps) => {
+  const {
+    recipeUrl,
+    recipeText,
+    image,
+    hasUrl,
+    hasText,
+    hasImage,
+    handleUrlChange,
+    handleTextChange,
+    handleFileSelect,
+    clearImage,
+  } = inputs;
+
+  return (
+    <>
+      <Input
+        placeholder="Enter recipe URL..."
+        value={recipeUrl}
+        onChange={handleUrlChange}
+        onKeyDown={onUrlKeyDown}
+        disabled={loading || hasImage || hasText}
+      />
+
+      <Textarea
+        placeholder="...or paste recipe text here"
+        value={recipeText}
+        onChange={handleTextChange}
+        disabled={loading || hasImage || hasUrl}
+        rows={6}
+      />
+
+      <div className="flex gap-2 items-center">
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleFileSelect}
+          disabled={loading || hasUrl || hasText}
+        />
+        {image && (
+          <>
+            <Text size="2" color="gray">
+              {image.name}
+            </Text>
+            <Button onClick={clearImage} disabled={loading} variant="outline">
+              Clear
+            </Button>
+          </>
+        )}
+      </div>
+    </>
+  );
+};

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/pages/FeatureSandboxPage.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/pages/FeatureSandboxPage.tsx
@@ -10,6 +10,7 @@ import { SpeechToText } from '../llm/SpeechToText';
 import { VoiceListGenerator } from '../llm/VoiceListGenerator';
 import { TextToSpeechVoices } from '../llm/TextToSpeechVoices';
 import { LLMSimplePromptTester } from '../llm/LLMPromptTester';
+import { RecipeScraperDemo } from '../llm/RecipeScraperDemo';
 import { QRCodeGenerator } from '../demos/QRCodeGenerator';
 import { LiveLocationsDemo } from '../demos/LiveLocationsDemo';
 import {
@@ -54,6 +55,11 @@ const FEATURE_SECTIONS: CollapsibleListItemConfig[] = [
     id: 'llm-prompt-tester',
     title: 'LLM Prompt Tester',
     content: <LLMSimplePromptTester />,
+  },
+  {
+    id: 'recipe-scraper',
+    title: 'Recipe Scraper (URL or Image)',
+    content: <RecipeScraperDemo />,
   },
   {
     id: 'bucket-demo',

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/utilities/recipe-scraper.utility.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/utilities/recipe-scraper.utility.tsx
@@ -1,22 +1,66 @@
 'use client';
 import { HTTP_METHOD, HTTP_HEADERS } from '@vigilant-broccoli/common-js';
 import { Text } from '@radix-ui/themes';
-import { Button, Input } from '@vigilant-broccoli/react-lib';
+import { Button, Input, Textarea } from '@vigilant-broccoli/react-lib';
 import { useState } from 'react';
 import { API_ENDPOINTS } from '../../constants/api-endpoints';
 import { authFetch } from '../../../../libs/auth';
+import {
+  UploadedImage,
+  readImageAsBase64,
+} from '../../utils/image-upload.utils';
+
+const buildScrapeRequestBody = (
+  recipeUrl: string,
+  recipeText: string,
+  image: UploadedImage | null,
+) => {
+  if (image) return { images: [image] };
+  if (recipeText.trim()) return { text: recipeText };
+  return { url: recipeUrl };
+};
 
 export const RecipeScraperUtilityContent = () => {
   const [recipeUrl, setRecipeUrl] = useState('');
+  const [recipeText, setRecipeText] = useState('');
+  const [image, setImage] = useState<UploadedImage | null>(null);
   const [recipeLoading, setRecipeLoading] = useState(false);
   const [recipeMessage, setRecipeMessage] = useState<{
     type: 'success' | 'error';
     text: string;
   } | null>(null);
 
+  const hasUrl = !!recipeUrl.trim();
+  const hasText = !!recipeText.trim();
+  const hasImage = !!image;
+  const hasAnyInput = hasUrl || hasText || hasImage;
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImage(await readImageAsBase64(file));
+    setRecipeUrl('');
+    setRecipeText('');
+  };
+
+  const clearImage = () => setImage(null);
+
+  const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRecipeUrl(e.target.value);
+    if (e.target.value) setRecipeText('');
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setRecipeText(e.target.value);
+    if (e.target.value) setRecipeUrl('');
+  };
+
   const handleScrapeRecipe = async () => {
-    if (!recipeUrl.trim()) {
-      setRecipeMessage({ type: 'error', text: 'Please enter a URL' });
+    if (!hasAnyInput) {
+      setRecipeMessage({
+        type: 'error',
+        text: 'Enter a URL, paste recipe text, or select an image',
+      });
       return;
     }
 
@@ -28,7 +72,9 @@ export const RecipeScraperUtilityContent = () => {
       headers: {
         ...HTTP_HEADERS.CONTENT_TYPE.JSON,
       },
-      body: JSON.stringify({ url: recipeUrl }),
+      body: JSON.stringify(
+        buildScrapeRequestBody(recipeUrl, recipeText, image),
+      ),
     });
 
     if (!response.ok) {
@@ -41,6 +87,8 @@ export const RecipeScraperUtilityContent = () => {
       return;
     }
     setRecipeUrl('');
+    setRecipeText('');
+    setImage(null);
     setRecipeMessage({
       type: 'success',
       text: 'Recipe downloaded successfully!',
@@ -56,18 +104,50 @@ export const RecipeScraperUtilityContent = () => {
 
   return (
     <>
-      <div className="flex gap-2 items-end">
+      <div className="flex flex-col gap-3">
         <Input
           placeholder="Enter recipe URL..."
           value={recipeUrl}
-          onChange={e => setRecipeUrl(e.target.value)}
+          onChange={handleUrlChange}
           onKeyDown={handleRecipeKeyDown}
-          disabled={recipeLoading}
-          className="flex-1"
+          disabled={recipeLoading || hasImage || hasText}
         />
+
+        <Textarea
+          placeholder="...or paste recipe text here"
+          value={recipeText}
+          onChange={handleTextChange}
+          disabled={recipeLoading || hasImage || hasUrl}
+          rows={6}
+        />
+
+        <div className="flex gap-2 items-center">
+          <input
+            type="file"
+            accept="image/*"
+            onChange={handleFileSelect}
+            disabled={recipeLoading || hasUrl || hasText}
+          />
+          {image && (
+            <>
+              <Text size="2" color="gray">
+                {image.name}
+              </Text>
+              <Button
+                onClick={clearImage}
+                disabled={recipeLoading}
+                variant="outline"
+              >
+                Clear
+              </Button>
+            </>
+          )}
+        </div>
+
         <Button
           onClick={handleScrapeRecipe}
-          disabled={recipeLoading || !recipeUrl.trim()}
+          disabled={recipeLoading || !hasAnyInput}
+          className="self-end"
         >
           {recipeLoading ? 'Scraping...' : 'Download'}
         </Button>

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/utilities/recipe-scraper.utility.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/utilities/recipe-scraper.utility.tsx
@@ -1,67 +1,28 @@
 'use client';
 import { HTTP_METHOD, HTTP_HEADERS } from '@vigilant-broccoli/common-js';
 import { Text } from '@radix-ui/themes';
-import { Button, Input, Textarea } from '@vigilant-broccoli/react-lib';
+import { Button } from '@vigilant-broccoli/react-lib';
 import { useState } from 'react';
 import { API_ENDPOINTS } from '../../constants/api-endpoints';
 import { authFetch } from '../../../../libs/auth';
-import {
-  UploadedImage,
-  readImageAsBase64,
-} from '../../utils/image-upload.utils';
+import { useRecipeScraperInputs } from '../../hooks/useRecipeScraperInputs';
+import { RecipeScraperInputs } from '../llm/RecipeScraperInputs';
 
 const MESSAGE_TYPE = {
   SUCCESS: 'success',
   ERROR: 'error',
 } as const;
 
-const buildScrapeRequestBody = (
-  recipeUrl: string,
-  recipeText: string,
-  image: UploadedImage | null,
-) => {
-  if (image) return { images: [image] };
-  if (recipeText.trim()) return { text: recipeText };
-  return { url: recipeUrl };
-};
-
 export const RecipeScraperUtilityContent = () => {
-  const [recipeUrl, setRecipeUrl] = useState('');
-  const [recipeText, setRecipeText] = useState('');
-  const [image, setImage] = useState<UploadedImage | null>(null);
+  const inputs = useRecipeScraperInputs();
   const [recipeLoading, setRecipeLoading] = useState(false);
   const [recipeMessage, setRecipeMessage] = useState<{
     type: (typeof MESSAGE_TYPE)[keyof typeof MESSAGE_TYPE];
     text: string;
   } | null>(null);
 
-  const hasUrl = !!recipeUrl.trim();
-  const hasText = !!recipeText.trim();
-  const hasImage = !!image;
-  const hasAnyInput = hasUrl || hasText || hasImage;
-
-  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setImage(await readImageAsBase64(file));
-    setRecipeUrl('');
-    setRecipeText('');
-  };
-
-  const clearImage = () => setImage(null);
-
-  const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setRecipeUrl(e.target.value);
-    if (e.target.value) setRecipeText('');
-  };
-
-  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setRecipeText(e.target.value);
-    if (e.target.value) setRecipeUrl('');
-  };
-
   const handleScrapeRecipe = async () => {
-    if (!hasAnyInput) {
+    if (!inputs.hasAnyInput) {
       setRecipeMessage({
         type: MESSAGE_TYPE.ERROR,
         text: 'Enter a URL, paste recipe text, or select an image',
@@ -77,9 +38,7 @@ export const RecipeScraperUtilityContent = () => {
       headers: {
         ...HTTP_HEADERS.CONTENT_TYPE.JSON,
       },
-      body: JSON.stringify(
-        buildScrapeRequestBody(recipeUrl, recipeText, image),
-      ),
+      body: JSON.stringify(inputs.requestBody),
     });
 
     if (!response.ok) {
@@ -91,9 +50,7 @@ export const RecipeScraperUtilityContent = () => {
       setRecipeLoading(false);
       return;
     }
-    setRecipeUrl('');
-    setRecipeText('');
-    setImage(null);
+    inputs.reset();
     setRecipeMessage({
       type: MESSAGE_TYPE.SUCCESS,
       text: 'Recipe downloaded successfully!',
@@ -110,48 +67,15 @@ export const RecipeScraperUtilityContent = () => {
   return (
     <>
       <div className="flex flex-col gap-3">
-        <Input
-          placeholder="Enter recipe URL..."
-          value={recipeUrl}
-          onChange={handleUrlChange}
-          onKeyDown={handleRecipeKeyDown}
-          disabled={recipeLoading || hasImage || hasText}
+        <RecipeScraperInputs
+          inputs={inputs}
+          loading={recipeLoading}
+          onUrlKeyDown={handleRecipeKeyDown}
         />
-
-        <Textarea
-          placeholder="...or paste recipe text here"
-          value={recipeText}
-          onChange={handleTextChange}
-          disabled={recipeLoading || hasImage || hasUrl}
-          rows={6}
-        />
-
-        <div className="flex gap-2 items-center">
-          <input
-            type="file"
-            accept="image/*"
-            onChange={handleFileSelect}
-            disabled={recipeLoading || hasUrl || hasText}
-          />
-          {image && (
-            <>
-              <Text size="2" color="gray">
-                {image.name}
-              </Text>
-              <Button
-                onClick={clearImage}
-                disabled={recipeLoading}
-                variant="outline"
-              >
-                Clear
-              </Button>
-            </>
-          )}
-        </div>
 
         <Button
           onClick={handleScrapeRecipe}
-          disabled={recipeLoading || !hasAnyInput}
+          disabled={recipeLoading || !inputs.hasAnyInput}
           className="self-end"
         >
           {recipeLoading ? 'Scraping...' : 'Download'}

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/utilities/recipe-scraper.utility.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/utilities/recipe-scraper.utility.tsx
@@ -10,6 +10,11 @@ import {
   readImageAsBase64,
 } from '../../utils/image-upload.utils';
 
+const MESSAGE_TYPE = {
+  SUCCESS: 'success',
+  ERROR: 'error',
+} as const;
+
 const buildScrapeRequestBody = (
   recipeUrl: string,
   recipeText: string,
@@ -26,7 +31,7 @@ export const RecipeScraperUtilityContent = () => {
   const [image, setImage] = useState<UploadedImage | null>(null);
   const [recipeLoading, setRecipeLoading] = useState(false);
   const [recipeMessage, setRecipeMessage] = useState<{
-    type: 'success' | 'error';
+    type: (typeof MESSAGE_TYPE)[keyof typeof MESSAGE_TYPE];
     text: string;
   } | null>(null);
 
@@ -58,7 +63,7 @@ export const RecipeScraperUtilityContent = () => {
   const handleScrapeRecipe = async () => {
     if (!hasAnyInput) {
       setRecipeMessage({
-        type: 'error',
+        type: MESSAGE_TYPE.ERROR,
         text: 'Enter a URL, paste recipe text, or select an image',
       });
       return;
@@ -80,7 +85,7 @@ export const RecipeScraperUtilityContent = () => {
     if (!response.ok) {
       const data = await response.json();
       setRecipeMessage({
-        type: 'error',
+        type: MESSAGE_TYPE.ERROR,
         text: data.error || 'Failed to scrape recipe',
       });
       setRecipeLoading(false);
@@ -90,7 +95,7 @@ export const RecipeScraperUtilityContent = () => {
     setRecipeText('');
     setImage(null);
     setRecipeMessage({
-      type: 'success',
+      type: MESSAGE_TYPE.SUCCESS,
       text: 'Recipe downloaded successfully!',
     });
     setRecipeLoading(false);
@@ -156,7 +161,7 @@ export const RecipeScraperUtilityContent = () => {
       {recipeMessage && (
         <Text
           size="2"
-          color={recipeMessage.type === 'success' ? 'green' : 'red'}
+          color={recipeMessage.type === MESSAGE_TYPE.SUCCESS ? 'green' : 'red'}
         >
           {recipeMessage.text}
         </Text>

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/constants/api-endpoints.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/constants/api-endpoints.ts
@@ -95,6 +95,7 @@ export const API_ENDPOINTS = {
 
   // Recipe
   RECIPE_SCRAPE: '/api/recipe/scrape',
+  RECIPE_SCRAPE_PREVIEW: '/api/recipe/scrape-preview',
 
   // Chat
   CHAT_PUBLISH: '/api/chat/publish',

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/hooks/useRecipeScraperInputs.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/hooks/useRecipeScraperInputs.ts
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { UploadedImage, readImageAsBase64 } from '../utils/image-upload.utils';
+
+const buildScrapeRequestBody = (
+  recipeUrl: string,
+  recipeText: string,
+  image: UploadedImage | null,
+) => {
+  if (image) return { images: [image] };
+  if (recipeText.trim()) return { text: recipeText };
+  return { url: recipeUrl };
+};
+
+export const useRecipeScraperInputs = () => {
+  const [recipeUrl, setRecipeUrl] = useState('');
+  const [recipeText, setRecipeText] = useState('');
+  const [image, setImage] = useState<UploadedImage | null>(null);
+
+  const hasUrl = !!recipeUrl.trim();
+  const hasText = !!recipeText.trim();
+  const hasImage = !!image;
+  const hasAnyInput = hasUrl || hasText || hasImage;
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setImage(await readImageAsBase64(file));
+    setRecipeUrl('');
+    setRecipeText('');
+  };
+
+  const clearImage = () => setImage(null);
+
+  const handleUrlChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRecipeUrl(e.target.value);
+    if (e.target.value) setRecipeText('');
+  };
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setRecipeText(e.target.value);
+    if (e.target.value) setRecipeUrl('');
+  };
+
+  const reset = () => {
+    setRecipeUrl('');
+    setRecipeText('');
+    setImage(null);
+  };
+
+  return {
+    recipeUrl,
+    recipeText,
+    image,
+    hasUrl,
+    hasText,
+    hasImage,
+    hasAnyInput,
+    handleFileSelect,
+    clearImage,
+    handleUrlChange,
+    handleTextChange,
+    reset,
+    requestBody: buildScrapeRequestBody(recipeUrl, recipeText, image),
+  };
+};

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/utils/image-upload.utils.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/utils/image-upload.utils.ts
@@ -1,0 +1,19 @@
+export type UploadedImage = {
+  name: string;
+  base64: string;
+  mimeType: string;
+};
+
+export const readImageAsBase64 = (file: File): Promise<UploadedImage> =>
+  new Promise(resolve => {
+    const reader = new FileReader();
+    reader.onload = e => {
+      const dataUrl = e.target?.result as string;
+      resolve({
+        name: file.name,
+        base64: dataUrl.split(',')[1],
+        mimeType: file.type,
+      });
+    };
+    reader.readAsDataURL(file);
+  });

--- a/projects/nx-workspace/libs/@vigilant-broccoli/common-js/src/lib/services/services.consts.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/common-js/src/lib/services/services.consts.ts
@@ -23,6 +23,7 @@ export const VB_EXPRESS_ENDPOINT = {
   TASKS_PARSE_IMAGE: 'api/tasks/parse-image',
   WHERE_IS_ANALYZE: 'api/where-is/analyze',
   PRICE_TRACKER_ANALYZE: 'api/price-tracker/analyze',
+  RECIPE_SCRAPE: 'api/recipe/scrape',
 };
 
 export const VB_EXPRESS_ADMIN_ENDPOINT = {
@@ -40,4 +41,5 @@ export const VB_EXPRESS_SERVICE = {
   TEXT_TO_SPEECH: 'text-to-speech',
   WHERE_IS: 'where-is',
   PRICE_TRACKER: 'price-tracker',
+  RECIPE: 'recipe',
 };


### PR DESCRIPTION
## Summary
- Adds a new `POST /api/recipe/scrape` endpoint to `vb-express` that extracts a recipe as markdown from either a URL or one or more uploaded images (base64), reusing the existing HTML-cleaning/bot-detection logic for the URL path and routing both paths through the same LLM extraction prompt.
- Simplifies `vb-manager-next`'s existing `api/recipe/scrape` route to call the new vb-express endpoint instead of duplicating scraping/LLM logic, while preserving its local file-save + VS Code open behavior.
- Adds a new preview-only `api/recipe/scrape-preview` proxy route and a `RecipeScraperDemo` component wired into the `feature-sandbox` page, with a URL text input and an image file input (mutually exclusive), showing the returned markdown in a copyable preview.

## Test plan
- [x] `nx run vb-express:lint` — passes, no errors
- [x] `nx run vb-express:build` — builds successfully
- [x] `nx run vb-express:smoke` — passes, new route boots without requiring secrets at module load
- [x] `nx run vb-manager-next:lint` — passes, no errors (0 new warnings)
- [x] `nx run vb-manager-next:build` — builds successfully, new routes and `/feature-sandbox` page compile
- [ ] Manual end-to-end verification against live `vb-express`/LLM credentials (URL scrape + image upload in the sandbox) — not run in this session, recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)