### PR TITLE
test(fastify): Add unit test for api-key plugin fail-closed behavior

### DIFF
--- a/projects/nx-workspace/libs/@vigilant-broccoli/fastify/jest.config.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/fastify/jest.config.ts
@@ -1,0 +1,10 @@
+export default {
+  displayName: '@vigilant-broccoli/fastify',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'html'],
+  coverageDirectory: '../../../coverage/libs/@vigilant-broccoli/fastify',
+};

--- a/projects/nx-workspace/libs/@vigilant-broccoli/fastify/project.json
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/fastify/project.json
@@ -30,6 +30,13 @@
     },
     "lint": {
       "executor": "@nx/eslint:lint"
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/@vigilant-broccoli/fastify/jest.config.ts"
+      }
     }
   }
 }

--- a/projects/nx-workspace/libs/@vigilant-broccoli/fastify/src/plugins/api-key.plugin.spec.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/fastify/src/plugins/api-key.plugin.spec.ts
@@ -1,0 +1,68 @@
+import Fastify from 'fastify';
+import {
+  API_KEY_HEADER,
+  HTTP_STATUS_CODES,
+} from '@vigilant-broccoli/common-js';
+import { createApiKeyPlugin } from './api-key.plugin';
+
+const buildApp = (apiKey?: string) => {
+  const app = Fastify();
+  app.register(createApiKeyPlugin(apiKey));
+  app.get('/protected', async () => ({ ok: true }));
+  return app;
+};
+
+describe('createApiKeyPlugin', () => {
+  it('rejects requests with 500 when the api key is unset', async () => {
+    const app = buildApp(undefined);
+
+    const response = await app.inject({ method: 'GET', url: '/protected' });
+
+    expect(response.statusCode).toBe(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+    expect(response.json()).toEqual({ error: 'Unauthorized' });
+  });
+
+  it('rejects requests with 500 when the api key is an empty string', async () => {
+    const app = buildApp('');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: { [API_KEY_HEADER]: 'anything' },
+    });
+
+    expect(response.statusCode).toBe(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR);
+  });
+
+  it('rejects requests missing the api key header when configured', async () => {
+    const app = buildApp('secret');
+
+    const response = await app.inject({ method: 'GET', url: '/protected' });
+
+    expect(response.statusCode).toBe(HTTP_STATUS_CODES.UNAUTHORIZED);
+  });
+
+  it('rejects requests with an incorrect api key', async () => {
+    const app = buildApp('secret');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: { [API_KEY_HEADER]: 'wrong' },
+    });
+
+    expect(response.statusCode).toBe(HTTP_STATUS_CODES.UNAUTHORIZED);
+  });
+
+  it('allows requests with the correct api key', async () => {
+    const app = buildApp('secret');
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: { [API_KEY_HEADER]: 'secret' },
+    });
+
+    expect(response.statusCode).toBe(HTTP_STATUS_CODES.OK);
+  });
+});

--- a/projects/nx-workspace/libs/@vigilant-broccoli/fastify/tsconfig.spec.json
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/fastify/tsconfig.spec.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a Jest unit test (`api-key.plugin.spec.ts`) for `createApiKeyPlugin` that uses Fastify's `inject()` to exercise the fail-closed behavior added in #97.
- Covers the case from #97's test plan directly: API key unset (and empty string) → requests rejected with 500, instead of requiring a manual deploy to verify.
- Also covers missing header, wrong key (401), and correct key (200) for completeness.
- Wires up `jest.config.ts`, `tsconfig.spec.json`, and a `test` target in `project.json` for the `@vigilant-broccoli/fastify` lib, which had no test setup previously.

## Test plan
- [x] `nx run @vigilant-broccoli/fastify:test` — 5/5 tests pass
- [x] `nx run @vigilant-broccoli/fastify:build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)