### PR TITLE
ci(github-actions): Scope cron push triggers to main branch

### DIFF
--- a/.github/workflows/cron-backup.yml
+++ b/.github/workflows/cron-backup.yml
@@ -2,6 +2,7 @@ name: cron-backup
 
 on:
   push:
+    branches: [main]
     paths:
       - .github/workflows/cron-backup.yml
   schedule:

--- a/.github/workflows/cron-cleanup-workflow-runs.yml
+++ b/.github/workflows/cron-cleanup-workflow-runs.yml
@@ -2,6 +2,7 @@ name: cron-cleanup-workflow-runs
 
 on:
   push:
+    branches: [main]
     paths:
       - .github/workflows/cron-cleanup-workflow-runs.yml
   schedule:

--- a/.github/workflows/cron-deploy-journal.yml
+++ b/.github/workflows/cron-deploy-journal.yml
@@ -2,6 +2,7 @@ name: cron-deploy-journal
 
 on:
   push:
+    branches: [main]
     paths:
       - .github/workflows/cron-deploy-journal.yml
       - projects/nx-workspace/apps/ui/journal/**

--- a/.github/workflows/cron-utility-update-resume.yml
+++ b/.github/workflows/cron-utility-update-resume.yml
@@ -2,6 +2,7 @@ name: cron-utility-update-resume
 
 on:
   push:
+    branches: [main]
     paths:
       - .github/workflows/cron-utility-update-resume.yml
   schedule:


### PR DESCRIPTION
## Summary
- PRs #102 and #103 (Dependabot bumps of `pnpm/action-setup` and `actions/setup-node`) unexpectedly triggered `upload-resume` runs that failed
- Root cause: `cron-utility-update-resume.yml` and 3 other `cron-*.yml` workflows have a `push:` trigger scoped only by `paths:`, with no `branches:` restriction — pushing a Dependabot branch that touches the workflow file (since it has actions pinned inline) matches the path filter and fires the job on the PR branch
- The job then fails immediately because Dependabot-triggered runs don't receive repo secrets, so Vault/GCP auth can't proceed
- Fix: add `branches: [main]` to the `push` trigger in all four affected workflows so they only run on push-to-main, their schedule, or manual dispatch — not on PR/Dependabot branches
  - `cron-utility-update-resume.yml`
  - `cron-backup.yml`
  - `cron-deploy-journal.yml`
  - `cron-cleanup-workflow-runs.yml`

## Test plan
- [ ] Confirm a future Dependabot PR touching one of these workflow files no longer triggers the corresponding job
- [ ] Confirm each workflow still runs on its schedule / via `workflow_dispatch` / on a real push to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)