### PR TITLE
security(github-actions): Pin socket.io-client and disable install scripts in deploy-notify

### DIFF
--- a/.github/actions/deploy-notify/action.yml
+++ b/.github/actions/deploy-notify/action.yml
@@ -32,7 +32,7 @@ runs:
   steps:
     - name: Install socket.io-client
       shell: bash
-      run: npm install --no-save socket.io-client@4
+      run: npm install --no-save --ignore-scripts socket.io-client@4.8.3
 
     - name: Send notification
       shell: bash


### PR DESCRIPTION
## Summary
- Fixes M14 from SECURITY_AUDIT.md: `deploy-notify`'s composite action ran `npm install --no-save socket.io-client@4` (floating major version, install scripts enabled) in a job whose env already holds `SHARED_APP_TOKEN` and live WIF/OIDC credentials.
- Pins to the exact version already used elsewhere in the nx workspace (`socket.io-client@4.8.3`) and adds `--ignore-scripts` so no install-time script can run once secrets are in the job env.
- Marks M14 as fixed in `SECURITY_AUDIT.md`.

## Test plan
- [ ] `deploy.yml` / `notify-complete.yml` run `deploy-notify` successfully (install step + notification still succeed)
- [ ] Confirm no other workflow depends on a script running during `socket.io-client` install

🤖 Generated with [Claude Code](https://claude.com/claude-code)