### PR TITLE
security(bucket-service): Fix authenticated path traversal (H6)

### DIFF
--- a/projects/nx-workspace/apps/api/bucket-service/src/routes/bucket.ts
+++ b/projects/nx-workspace/apps/api/bucket-service/src/routes/bucket.ts
@@ -1,4 +1,5 @@
 import { FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify';
+import * as path from 'path';
 import {
   createBucketService,
   BucketProvider,
@@ -15,7 +16,10 @@ const PROVIDER_PARAM = 'provider';
 const ERROR_PROVIDER_REQUIRED = 'provider query parameter is required';
 const ERROR_NO_FILES = 'No valid files provided';
 const MESSAGE_FILE_DELETED = 'File deleted successfully';
-const VALID_PROVIDERS = new Set<string>(Object.values(BucketProvider));
+const VALID_PROVIDERS = new Set<string>([
+  BucketProvider.CLOUDFLARE_R2,
+  BucketProvider.GOOGLE_CLOUD_STORAGE,
+]);
 const bucketServices = new Map<BucketProvider, IBucketProvider>();
 
 function getBucketService(provider: string) {
@@ -76,7 +80,7 @@ const bucketRoutes: FastifyPluginAsync = async app => {
     const collected: { filename: string; buffer: Buffer }[] = [];
     for await (const part of parts) {
       collected.push({
-        filename: part.filename,
+        filename: path.basename(part.filename),
         buffer: await part.toBuffer(),
       });
     }

--- a/projects/nx-workspace/apps/api/bucket-service/src/routes/bucket.ts
+++ b/projects/nx-workspace/apps/api/bucket-service/src/routes/bucket.ts
@@ -16,10 +16,7 @@ const PROVIDER_PARAM = 'provider';
 const ERROR_PROVIDER_REQUIRED = 'provider query parameter is required';
 const ERROR_NO_FILES = 'No valid files provided';
 const MESSAGE_FILE_DELETED = 'File deleted successfully';
-const VALID_PROVIDERS = new Set<string>([
-  BucketProvider.CLOUDFLARE_R2,
-  BucketProvider.GOOGLE_CLOUD_STORAGE,
-]);
+const VALID_PROVIDERS = new Set<string>(Object.values(BucketProvider));
 const bucketServices = new Map<BucketProvider, IBucketProvider>();
 
 function getBucketService(provider: string) {

--- a/projects/nx-workspace/libs/@vigilant-broccoli/storage/src/lib/bucket/providers/local.provider.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/storage/src/lib/bucket/providers/local.provider.ts
@@ -24,18 +24,18 @@ export class LocalBucketProvider implements IBucketProvider {
   }
 
   async upload(destinationName: string, buffer: Buffer): Promise<void> {
-    const destinationPath = path.join(this.bucketPath, destinationName);
+    const destinationPath = this.resolveContainedPath(destinationName);
     await fs.mkdir(path.dirname(destinationPath), { recursive: true });
     await fs.writeFile(destinationPath, buffer);
   }
 
   async download(fileName: string, destinationPath: string): Promise<void> {
-    const sourcePath = path.join(this.bucketPath, fileName);
+    const sourcePath = this.resolveContainedPath(fileName);
     await fs.copyFile(sourcePath, destinationPath);
   }
 
   async delete(fileName: string): Promise<void> {
-    const filePath = path.join(this.bucketPath, fileName);
+    const filePath = this.resolveContainedPath(fileName);
     await fs.unlink(filePath);
   }
 
@@ -60,7 +60,7 @@ export class LocalBucketProvider implements IBucketProvider {
 
   async exists(fileName: string): Promise<boolean> {
     try {
-      await fs.access(path.join(this.bucketPath, fileName));
+      await fs.access(this.resolveContainedPath(fileName));
       return true;
     } catch {
       return false;
@@ -68,8 +68,20 @@ export class LocalBucketProvider implements IBucketProvider {
   }
 
   async read(fileName: string): Promise<Buffer> {
-    const filePath = path.join(this.bucketPath, fileName);
+    const filePath = this.resolveContainedPath(fileName);
     return await fs.readFile(filePath);
+  }
+
+  private resolveContainedPath(fileName: string): string {
+    const bucketRoot = path.resolve(this.bucketPath);
+    const resolved = path.resolve(bucketRoot, fileName);
+    if (
+      resolved !== bucketRoot &&
+      !resolved.startsWith(bucketRoot + path.sep)
+    ) {
+      throw new Error(`Invalid file path: ${fileName}`);
+    }
+    return resolved;
   }
 
   private async readDirRecursive(dir: string): Promise<string[]> {


### PR DESCRIPTION
## Summary
- `LocalBucketProvider` now resolves every file path through a `resolveContainedPath` helper that verifies the result stays within the resolved bucket root, throwing if it doesn't — this is the actual fix for the path-traversal issue (H6), and applies regardless of which provider is selected.
- Sanitize multipart `part.filename` to its basename on upload as defense in depth.
- All providers (including `local`) remain selectable via the `provider` param, so local dev workflows are unaffected — the fix is contained to `LocalBucketProvider` itself rather than a route-level whitelist.

## Test plan
- [x] `nx run bucket-service:build` passes
- [x] `nx run storage:build` passes
- [x] `nx run bucket-service:lint` passes
- [x] `nx run storage:lint` passes (pre-existing unrelated warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)