### PR TITLE
fix(health-check): Run http_checks in parallel instead of serially

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,3 @@
 
 - `ci-rotate-secrets.yml` gates `rotate` on `needs: notify-start`, so the actual rotation waits for the notification job (checkout + Vault fetch + notify, ~30–60s) even though the notification is fire-and-forget (`continue-on-error: true`). Drop the `needs: notify-start` so both jobs start concurrently — matching `deploy.yml`, where `notify-start` already runs in parallel (its other jobs gate on `gitleaks` instead).
 - Survey of all other `deploy-notify` consumers (so this doesn't need re-checking): `deploy.yml` is already parallel — nothing gates on its `notify-start`, and the `gitleaks` gate on the deploy jobs is a deliberate security gate, not a notification; `notify-complete.yml` is inherently sequential by design (`workflow_run`-triggered completion notification after deploy/ci-rotate-secrets finish). `ci-rotate-secrets.yml` is the only workflow with the blocking pattern, so this item is fully scoped to the one `needs:` line.
-
-### 562311. `health-check.sh` is fully serial with retry sleeps
-
-**`projects/nx-workspace/scripts/shell/health-check.sh`** — 10 endpoints checked one after another (each up to 3 attempts × `--max-time 30` + `sleep 5`), then gcloud, Vault, terraform+SSH, and an AMQP connect. A cold-start-heavy run takes minutes. **Fix:** run the `http_check`s as background jobs and `wait`; wall time drops from sum to max.

--- a/projects/nx-workspace/scripts/shell/health-check.sh
+++ b/projects/nx-workspace/scripts/shell/health-check.sh
@@ -9,6 +9,9 @@ GCP_PROJECT="${GCP_PROJECT:-vigilant-broccoli}"
 PASS=0
 FAIL=0
 
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
 check() {
   local name="$1"
   local status="$2"
@@ -21,41 +24,67 @@ check() {
   fi
 }
 
-http_check() {
+http_check_start() {
   local name="$1"
   local url="$2"
   local expected="${3:-200}"
-  local code
-  # Retry to tolerate scale-to-zero cold starts (first request wakes the service).
-  for attempt in 1 2 3; do
-    code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$url" 2>/dev/null) || code="timeout"
-    [ "$code" = "$expected" ] && break
-    [ "$attempt" -lt 3 ] && sleep 5
-  done
-  if [ "$code" = "$expected" ]; then
-    check "$name" "ok"
-  else
-    check "$name" "HTTP $code (expected $expected)"
-  fi
+  local outfile="$TMP_DIR/$name"
+  (
+    local code
+    # Retry to tolerate scale-to-zero cold starts (first request wakes the service).
+    for attempt in 1 2 3; do
+      code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$url" 2>/dev/null) || code="timeout"
+      [ "$code" = "$expected" ] && break
+      [ "$attempt" -lt 3 ] && sleep 5
+    done
+    if [ "$code" = "$expected" ]; then
+      echo "ok" > "$outfile"
+    else
+      echo "HTTP $code (expected $expected)" > "$outfile"
+    fi
+  ) &
+}
+
+http_check_finish() {
+  local name="$1"
+  check "$name" "$(cat "$TMP_DIR/$name")"
 }
 
 echo "=== Infrastructure Health Check ==="
 echo ""
 
 echo "[Fly.io Apps]"
-http_check "staging-vb-express" "https://staging-vb-express.fly.dev"
-http_check "staging-vb-email-service" "https://staging-vb-email-service.fly.dev"
-http_check "staging-vb-llm-service" "https://staging-vb-llm-service.fly.dev"
-http_check "staging-vb-storage-service" "https://staging-vb-storage-service.fly.dev"
-http_check "staging-email-subscription-service" "https://staging-email-subscription-service.fly.dev"
+FLY_APPS=(
+  "staging-vb-express|https://staging-vb-express.fly.dev"
+  "staging-vb-email-service|https://staging-vb-email-service.fly.dev"
+  "staging-vb-llm-service|https://staging-vb-llm-service.fly.dev"
+  "staging-vb-storage-service|https://staging-vb-storage-service.fly.dev"
+  "staging-email-subscription-service|https://staging-email-subscription-service.fly.dev"
+)
+for entry in "${FLY_APPS[@]}"; do
+  http_check_start "${entry%%|*}" "${entry#*|}"
+done
+wait
+for entry in "${FLY_APPS[@]}"; do
+  http_check_finish "${entry%%|*}"
+done
 
 echo ""
 echo "[Websites]"
-http_check "harryliu.dev" "https://harryliu.dev"
-http_check "cloud8skate.com" "https://cloud8skate.com"
-http_check "staging-hearth" "https://staging-hearth.vercel.app"
-http_check "findme" "https://findme-kohl.vercel.app"
-http_check "git.harryliu.dev" "https://git.harryliu.dev"
+WEBSITES=(
+  "harryliu.dev|https://harryliu.dev"
+  "cloud8skate.com|https://cloud8skate.com"
+  "staging-hearth|https://staging-hearth.vercel.app"
+  "findme|https://findme-kohl.vercel.app"
+  "git.harryliu.dev|https://git.harryliu.dev"
+)
+for entry in "${WEBSITES[@]}"; do
+  http_check_start "${entry%%|*}" "${entry#*|}"
+done
+wait
+for entry in "${WEBSITES[@]}"; do
+  http_check_finish "${entry%%|*}"
+done
 
 echo ""
 echo "[GCP VM]"


### PR DESCRIPTION
## Summary
- `health-check.sh`'s 10 endpoint checks ran fully serially (each up to 3 attempts x `--max-time 30` + `sleep 5`), making a cold-start-heavy run take minutes.
- `http_check` split into `http_check_start` (launches the curl retry loop in a backgrounded subshell, writes its result to a temp file) and `http_check_finish` (reads that result and reports it via the existing `check` helper).
- Both the `[Fly.io Apps]` and `[Websites]` sections now launch their checks concurrently and `wait` before printing results — wall time drops from the sum of all checks to the max of the slowest one, per section.
- gcloud, Vault, terraform+SSH, and the AMQP connect check are left serial/unchanged, matching the scope of TODO item 562311.
- Removed the resolved `### 562311.` item from `TODO.md`.

## Test plan
- [x] `bash -n health-check.sh` — syntax check passes
- [x] Verified the background-job + temp-file + `wait` mechanics in isolation (5 x 1s dummy checks completed in ~1s instead of ~5s, all results reported correctly)
- [ ] Run `health-check.sh` against live infra endpoints (requires network/VPN access not available in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)