### PR TITLE
ci(ci-rotate-secrets): Run rotate concurrently with notify-start

### DIFF
--- a/.github/workflows/ci-rotate-secrets.yml
+++ b/.github/workflows/ci-rotate-secrets.yml
@@ -35,7 +35,6 @@ jobs:
           shared_app_token: ${{ env.SHARED_APP_TOKEN }}
 
   rotate:
-    needs: notify-start
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7

--- a/TODO.md
+++ b/TODO.md
@@ -44,11 +44,6 @@
 
 - The Angular 21 toolchain (~25 devDependencies) exists for one app, `cloud-8-skate-angular`. Migrating it to the React/Next stack removes the largest maintenance burden in the workspace.
 
-### efa939. Parallelize notify-start in ci-rotate-secrets
-
-- `ci-rotate-secrets.yml` gates `rotate` on `needs: notify-start`, so the actual rotation waits for the notification job (checkout + Vault fetch + notify, ~30–60s) even though the notification is fire-and-forget (`continue-on-error: true`). Drop the `needs: notify-start` so both jobs start concurrently — matching `deploy.yml`, where `notify-start` already runs in parallel (its other jobs gate on `gitleaks` instead).
-- Survey of all other `deploy-notify` consumers (so this doesn't need re-checking): `deploy.yml` is already parallel — nothing gates on its `notify-start`, and the `gitleaks` gate on the deploy jobs is a deliberate security gate, not a notification; `notify-complete.yml` is inherently sequential by design (`workflow_run`-triggered completion notification after deploy/ci-rotate-secrets finish). `ci-rotate-secrets.yml` is the only workflow with the blocking pattern, so this item is fully scoped to the one `needs:` line.
-
 ### 562311. `health-check.sh` is fully serial with retry sleeps
 
 **`projects/nx-workspace/scripts/shell/health-check.sh`** — 10 endpoints checked one after another (each up to 3 attempts × `--max-time 30` + `sleep 5`), then gcloud, Vault, terraform+SSH, and an AMQP connect. A cold-start-heavy run takes minutes. **Fix:** run the `http_check`s as background jobs and `wait`; wall time drops from sum to max.

--- a/TODO.md
+++ b/TODO.md
@@ -43,8 +43,3 @@
 ### 1c8bcf. Framework surface
 
 - The Angular 21 toolchain (~25 devDependencies) exists for one app, `cloud-8-skate-angular`. Migrating it to the React/Next stack removes the largest maintenance burden in the workspace.
-
-### efa939. Parallelize notify-start in ci-rotate-secrets
-
-- `ci-rotate-secrets.yml` gates `rotate` on `needs: notify-start`, so the actual rotation waits for the notification job (checkout + Vault fetch + notify, ~30–60s) even though the notification is fire-and-forget (`continue-on-error: true`). Drop the `needs: notify-start` so both jobs start concurrently — matching `deploy.yml`, where `notify-start` already runs in parallel (its other jobs gate on `gitleaks` instead).
-- Survey of all other `deploy-notify` consumers (so this doesn't need re-checking): `deploy.yml` is already parallel — nothing gates on its `notify-start`, and the `gitleaks` gate on the deploy jobs is a deliberate security gate, not a notification; `notify-complete.yml` is inherently sequential by design (`workflow_run`-triggered completion notification after deploy/ci-rotate-secrets finish). `ci-rotate-secrets.yml` is the only workflow with the blocking pattern, so this item is fully scoped to the one `needs:` line.


### PR DESCRIPTION
## Summary
- Drops `needs: notify-start` from the `rotate` job in `ci-rotate-secrets.yml` so it starts concurrently with the fire-and-forget notification job instead of waiting on it (~30-60s), matching the already-parallel pattern used in `deploy.yml`.
- Removes the resolved `efa939` item from `TODO.md`.

## Test plan
- [ ] Trigger `ci-rotate-secrets` via `workflow_dispatch` and confirm `notify-start` and `rotate` start at the same time in the Actions run graph.
- [ ] Confirm the `deploy` job still correctly waits on `rotate` to finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)