### PR TITLE
fix(health-check): Run HTTP endpoint checks concurrently

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -48,7 +48,3 @@
 
 - `ci-rotate-secrets.yml` gates `rotate` on `needs: notify-start`, so the actual rotation waits for the notification job (checkout + Vault fetch + notify, ~30–60s) even though the notification is fire-and-forget (`continue-on-error: true`). Drop the `needs: notify-start` so both jobs start concurrently — matching `deploy.yml`, where `notify-start` already runs in parallel (its other jobs gate on `gitleaks` instead).
 - Survey of all other `deploy-notify` consumers (so this doesn't need re-checking): `deploy.yml` is already parallel — nothing gates on its `notify-start`, and the `gitleaks` gate on the deploy jobs is a deliberate security gate, not a notification; `notify-complete.yml` is inherently sequential by design (`workflow_run`-triggered completion notification after deploy/ci-rotate-secrets finish). `ci-rotate-secrets.yml` is the only workflow with the blocking pattern, so this item is fully scoped to the one `needs:` line.
-
-### 562311. `health-check.sh` is fully serial with retry sleeps
-
-**`projects/nx-workspace/scripts/shell/health-check.sh`** — 10 endpoints checked one after another (each up to 3 attempts × `--max-time 30` + `sleep 5`), then gcloud, Vault, terraform+SSH, and an AMQP connect. A cold-start-heavy run takes minutes. **Fix:** run the `http_check`s as background jobs and `wait`; wall time drops from sum to max.

--- a/projects/nx-workspace/scripts/shell/health-check.sh
+++ b/projects/nx-workspace/scripts/shell/health-check.sh
@@ -21,10 +21,16 @@ check() {
   fi
 }
 
-http_check() {
+HC_TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$HC_TMPDIR"' EXIT
+
+# Runs in a background job; result is written to a file so the parent shell
+# can tally PASS/FAIL after `wait`, since background subshells can't mutate them.
+http_check_bg() {
   local name="$1"
   local url="$2"
   local expected="${3:-200}"
+  local outfile="$4"
   local code
   # Retry to tolerate scale-to-zero cold starts (first request wakes the service).
   for attempt in 1 2 3; do
@@ -33,29 +39,57 @@ http_check() {
     [ "$attempt" -lt 3 ] && sleep 5
   done
   if [ "$code" = "$expected" ]; then
-    check "$name" "ok"
+    echo "ok" > "$outfile"
   else
-    check "$name" "HTTP $code (expected $expected)"
+    echo "HTTP $code (expected $expected)" > "$outfile"
   fi
+}
+
+declare -a HC_NAMES=()
+declare -a HC_FILES=()
+
+queue_http_check() {
+  local name="$1"
+  local url="$2"
+  local expected="${3:-200}"
+  local outfile="$HC_TMPDIR/${#HC_NAMES[@]}"
+  HC_NAMES+=("$name")
+  HC_FILES+=("$outfile")
+  http_check_bg "$name" "$url" "$expected" "$outfile" &
+}
+
+print_http_check() {
+  check "${HC_NAMES[$1]}" "$(cat "${HC_FILES[$1]}")"
 }
 
 echo "=== Infrastructure Health Check ==="
 echo ""
 
+queue_http_check "staging-vb-express" "https://staging-vb-express.fly.dev"
+queue_http_check "staging-vb-email-service" "https://staging-vb-email-service.fly.dev"
+queue_http_check "staging-vb-llm-service" "https://staging-vb-llm-service.fly.dev"
+queue_http_check "staging-vb-storage-service" "https://staging-vb-storage-service.fly.dev"
+queue_http_check "staging-email-subscription-service" "https://staging-email-subscription-service.fly.dev"
+FLY_COUNT=${#HC_NAMES[@]}
+
+queue_http_check "harryliu.dev" "https://harryliu.dev"
+queue_http_check "cloud8skate.com" "https://cloud8skate.com"
+queue_http_check "staging-hearth" "https://staging-hearth.vercel.app"
+queue_http_check "findme" "https://findme-kohl.vercel.app"
+queue_http_check "git.harryliu.dev" "https://git.harryliu.dev"
+
+wait
+
 echo "[Fly.io Apps]"
-http_check "staging-vb-express" "https://staging-vb-express.fly.dev"
-http_check "staging-vb-email-service" "https://staging-vb-email-service.fly.dev"
-http_check "staging-vb-llm-service" "https://staging-vb-llm-service.fly.dev"
-http_check "staging-vb-storage-service" "https://staging-vb-storage-service.fly.dev"
-http_check "staging-email-subscription-service" "https://staging-email-subscription-service.fly.dev"
+for ((i = 0; i < FLY_COUNT; i++)); do
+  print_http_check "$i"
+done
 
 echo ""
 echo "[Websites]"
-http_check "harryliu.dev" "https://harryliu.dev"
-http_check "cloud8skate.com" "https://cloud8skate.com"
-http_check "staging-hearth" "https://staging-hearth.vercel.app"
-http_check "findme" "https://findme-kohl.vercel.app"
-http_check "git.harryliu.dev" "https://git.harryliu.dev"
+for ((i = FLY_COUNT; i < ${#HC_NAMES[@]}; i++)); do
+  print_http_check "$i"
+done
 
 echo ""
 echo "[GCP VM]"


### PR DESCRIPTION
## Summary
- Resolves TODO 562311: `health-check.sh`'s 10 endpoint checks ran fully serially (each up to 3 attempts x 30s timeout + 5s sleep), making cold-start-heavy runs take minutes.
- Queue each `http_check` as a background job writing its result to a temp file, `wait` for all of them, then tally/print results in the main shell — wall time drops from the sum of all checks to the max of any one.
- Removed the resolved item from `TODO.md` (P3 heading kept — other items remain under it).

## Test plan
- [x] `bash -n` syntax check on the modified script
- [x] Ran a standalone harness reproducing the queue/background/wait/print pattern against real URLs — confirmed elapsed time matched the slowest single check (max) rather than the sum of all checks (sandbox network was blocked, but retry/timeout durations lined up exactly with parallel execution)
- [ ] Run `health-check.sh` against live infrastructure to confirm output formatting and pass/fail counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)