### PR TITLE
feat(agent-sandbox): Mint short-lived GitHub App installation tokens for sandbox auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ Thumbs.db
 
 # Environments
 .env
+.github-app-key.pem
 .venv
 env/
 venv/

--- a/infrastructure/agent-sandbox/load-env-from-vault.sh
+++ b/infrastructure/agent-sandbox/load-env-from-vault.sh
@@ -32,7 +32,22 @@ vault kv get -format=json ${VAULT_KV_PATH}/secrets | jq '.data.data'
 ")
 
 CLAUDE_CODE_OAUTH_TOKEN=$(echo "$SECRETS" | jq -r '.CLAUDE_CODE_OAUTH_TOKEN // empty')
-GH_TOKEN=$(echo "$SECRETS" | jq -r '.AGENT_GITHUB_TOKEN // .GITHUB_TOKEN // empty')
+AGENT_GH_APP_ID=$(echo "$SECRETS" | jq -r '.AGENT_GH_APP_ID // empty')
+AGENT_GH_APP_PRIVATE_KEY=$(echo "$SECRETS" | jq -r '.AGENT_GH_APP_PRIVATE_KEY // empty')
+PEM_FILE="${SCRIPT_DIR}/.github-app-key.pem"
+
+if [ -n "$AGENT_GH_APP_ID" ] && [ -n "$AGENT_GH_APP_PRIVATE_KEY" ]; then
+  case "$AGENT_GH_APP_PRIVATE_KEY" in
+    -----BEGIN*) printf '%s\n' "$AGENT_GH_APP_PRIVATE_KEY" > "$PEM_FILE" ;;
+    *) echo "$AGENT_GH_APP_PRIVATE_KEY" | base64 -d > "$PEM_FILE" ;;
+  esac
+  chmod 600 "$PEM_FILE"
+  echo "Minting GitHub App installation token..."
+  GH_TOKEN=$("${SCRIPT_DIR}/mint-github-app-token.sh" "$AGENT_GH_APP_ID" "$PEM_FILE")
+else
+  rm -f "$PEM_FILE"
+  GH_TOKEN=$(echo "$SECRETS" | jq -r '.AGENT_GITHUB_TOKEN // .GITHUB_TOKEN // empty')
+fi
 
 if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
   echo "ERROR: CLAUDE_CODE_OAUTH_TOKEN not found in Vault (${VAULT_KV_PATH}/secrets)." >&2
@@ -43,12 +58,13 @@ if [ "${#CLAUDE_CODE_OAUTH_TOKEN}" -lt 100 ]; then
   exit 1
 fi
 if [ -z "$GH_TOKEN" ]; then
-  echo "WARNING: neither AGENT_GITHUB_TOKEN nor GITHUB_TOKEN found in Vault; sandbox will have read-only git access." >&2
+  echo "WARNING: no GitHub App credentials (AGENT_GH_APP_ID + AGENT_GH_APP_PRIVATE_KEY), AGENT_GITHUB_TOKEN, or GITHUB_TOKEN found in Vault; sandbox will have read-only git access." >&2
 fi
 
 cat > "$ENV_FILE" <<EOF
 CLAUDE_CODE_OAUTH_TOKEN=${CLAUDE_CODE_OAUTH_TOKEN}
 GH_TOKEN=${GH_TOKEN}
+AGENT_GH_APP_ID=${AGENT_GH_APP_ID}
 SANDBOX_FIREWALL=${SANDBOX_FIREWALL_VALUE:-on}
 SANDBOX_ALLOWED_DOMAINS=${SANDBOX_ALLOWED_DOMAINS_VALUE}
 SANDBOX_VAULT_ENV_VARS=${SANDBOX_VAULT_ENV_VARS_VALUE}

--- a/infrastructure/agent-sandbox/mint-github-app-token.sh
+++ b/infrastructure/agent-sandbox/mint-github-app-token.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/../config.sh"
+
+APP_ID=$1
+PEM_FILE=$2
+GITHUB_API=https://api.github.com
+
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+NOW=$(date +%s)
+HEADER=$(printf '{"alg":"RS256","typ":"JWT"}' | b64url)
+PAYLOAD=$(printf '{"iat":%d,"exp":%d,"iss":"%s"}' "$((NOW - 60))" "$((NOW + 540))" "$APP_ID" | b64url)
+SIGNATURE=$(printf '%s.%s' "$HEADER" "$PAYLOAD" | openssl dgst -sha256 -sign "$PEM_FILE" -binary | b64url)
+JWT="${HEADER}.${PAYLOAD}.${SIGNATURE}"
+
+INSTALLATION_ID=$(curl -fsS \
+  -H "Authorization: Bearer ${JWT}" \
+  -H "Accept: application/vnd.github+json" \
+  "${GITHUB_API}/app/installations" | jq -r '.[0].id // empty')
+
+if [ -z "$INSTALLATION_ID" ]; then
+  echo "ERROR: GitHub App ${APP_ID} has no installations — install it on ${GITHUB_OWNER}/${GITHUB_REPO}." >&2
+  exit 1
+fi
+
+curl -fsS -X POST \
+  -H "Authorization: Bearer ${JWT}" \
+  -H "Accept: application/vnd.github+json" \
+  -d "{\"repositories\":[\"${GITHUB_REPO}\"]}" \
+  "${GITHUB_API}/app/installations/${INSTALLATION_ID}/access_tokens" | jq -r '.token'

--- a/infrastructure/agent-sandbox/solve-todo.sh
+++ b/infrastructure/agent-sandbox/solve-todo.sh
@@ -34,9 +34,17 @@ if [ ! -f "$ENV_FILE" ]; then
   "$SCRIPT_DIR/load-env-from-vault.sh"
 fi
 
-if ! grep -q '^GH_TOKEN=.' "$ENV_FILE"; then
-  echo "ERROR: GH_TOKEN is empty in ${ENV_FILE} — solves cannot push or open PRs." >&2
-  echo "Add a fine-grained PAT to Vault (see docs/infrastructure/secret-management.md), then run: pnpm sandbox:up" >&2
+GH_TOKEN_VALUE=$(grep '^GH_TOKEN=' "$ENV_FILE" | cut -d= -f2-)
+APP_ID=$(grep '^AGENT_GH_APP_ID=' "$ENV_FILE" | cut -d= -f2-)
+PEM_FILE="$SCRIPT_DIR/.github-app-key.pem"
+if [ -n "$APP_ID" ] && [ -f "$PEM_FILE" ]; then
+  echo "Minting fresh GitHub App installation token for this batch..."
+  GH_TOKEN_VALUE=$("$SCRIPT_DIR/mint-github-app-token.sh" "$APP_ID" "$PEM_FILE")
+fi
+
+if [ -z "$GH_TOKEN_VALUE" ]; then
+  echo "ERROR: no GitHub token available — solves cannot push or open PRs." >&2
+  echo "Add GitHub App credentials or a fine-grained PAT to Vault (see docs/infrastructure/secret-management.md), then run: pnpm sandbox:up" >&2
   exit 1
 fi
 
@@ -61,6 +69,7 @@ for id in "${IDS[@]}"; do
   docker run --rm --init --name "vb-solve-${id}" \
     --cap-add NET_ADMIN --cap-add NET_RAW \
     --env-file "$ENV_FILE" \
+    -e GH_TOKEN="$GH_TOKEN_VALUE" \
     -e SOLVE_PROMPT="$(solve_prompt "$id")" \
     -e SOLVE_MODEL="$MODEL" \
     "$IMAGE" \


### PR DESCRIPTION
## Summary
- New `mint-github-app-token.sh`: signs an RS256 JWT with the App private key (openssl, no new dependencies), auto-discovers the installation, and mints a 1-hour installation token scoped to only this repo
- `load-env-from-vault.sh` prefers `AGENT_GH_APP_ID` + `AGENT_GH_APP_PRIVATE_KEY` from Vault (raw or base64 PEM), caches the key at `.github-app-key.pem` (0600, gitignored), and falls back to the existing PAT chain (`AGENT_GITHUB_TOKEN` → `GITHUB_TOKEN`) when App credentials are absent — zero regression until the App is configured
- `sandbox:solve` re-mints a fresh token per batch and overrides `GH_TOKEN` per container, so solves never run on an expired token; the empty-token guard now checks the final resolved value
- Why: auto-expiring repo-scoped tokens cap the blast radius of a leaked credential from an autonomous agent run, eliminate PAT-expiry breakage, and attribute solve PRs to the App bot for a clear autonomous-vs-human audit trail

## Test plan
- [x] `bash -n` on all three scripts
- [x] JWT pipeline verified with a throwaway RSA key: 3-part token, payload decodes to correct claims, RS256 signature round-trips via `openssl dgst -verify`
- [x] Fallback regression: loader rerun against Vault with no App credentials present → PAT chain still populates `GH_TOKEN`, no stale PEM left behind
- [ ] After creating the GitHub App and storing credentials in Vault: `pnpm sandbox:up` mints a token, and `pnpm sandbox:solve <id>` completes end-to-end as `<app>[bot]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)