### PR TITLE
ci(github-actions): Chain health check after secret rotation runs

### DIFF
--- a/.github/workflows/ci-health-check.yml
+++ b/.github/workflows/ci-health-check.yml
@@ -5,7 +5,7 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
   workflow_run:
-    workflows: ['deploy']
+    workflows: ['deploy', 'ci-rotate-secrets']
     types: [completed]
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Add `ci-rotate-secrets` to `ci-health-check`'s `workflow_run` trigger list so the health check fires after rotation runs, not just standalone deploys.
- The rotation workflow runs deploy as a reusable `workflow_call`, which never emits a `deploy` `workflow_run` event — so the health check silently skipped rotations while every other e2e/smoke/security suite already chained on `ci-rotate-secrets`.
- No job changes needed: the existing `if:` conclusion guard generalizes to any listed workflow.

## Test plan
- [ ] After merge, dispatch `ci-rotate-secrets` and confirm `ci-health-check` triggers on its successful completion.
- [ ] Confirm scheduled and `workflow_dispatch` runs of `ci-health-check` still work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)