### PR TITLE
fix(docs-md): Order prune-deployments after ensure-cf-project.

### DIFF
--- a/projects/nx-workspace/apps/ui/docs-md/project.json
+++ b/projects/nx-workspace/apps/ui/docs-md/project.json
@@ -37,7 +37,8 @@
       "command": "npx wrangler pages project list 2>&1 | grep -qw staging-docs-md || npx wrangler pages project create staging-docs-md --production-branch main"
     },
     "prune-deployments": {
-      "command": "npx tsx scripts/prune-wrangler-deployments.ts staging-docs-md 10"
+      "command": "npx tsx scripts/prune-wrangler-deployments.ts staging-docs-md 10",
+      "dependsOn": ["ensure-cf-project"]
     },
     "deploy": {
       "command": "npx wrangler pages deploy dist/docs-md --project-name staging-docs-md",


### PR DESCRIPTION
## Summary

- Fixes the `deploy-apps` failure in [run 29648189098](https://github.com/iamharryliu/vigilant-broccoli/actions/runs/29648189098/job/88089903817), where `docs-md:prune-deployments` failed and blocked `docs-md:deploy`.
- `deploy` listed `build`, `ensure-cf-project` and `prune-deployments` as sibling `dependsOn` entries, which nx schedules in parallel — there is no ordering between siblings. On the first-ever deploy, prune called the Cloudflare API at `14:33:54` and `ensure-cf-project` did not create `staging-docs-md` until `14:33:59`.
- Adds `dependsOn: ["ensure-cf-project"]` to `prune-deployments`, since listing deployments for a project requires that project to exist.
- The failed run did successfully create the Pages project, and Cloudflare assigned `staging-docs-md.pages.dev` with no suffix — confirming the `docs_pages_subdomain` default in `infrastructure/terraform/variables.tf` is correct. This also unblocks the `cloudflare_pages_domain.docs` 404 seen on `terraform apply`.

Note: `journal`, `personal-website-react`, `personal-website-frontend` and `cloud-8-skate-angular` share the same missing edge. They are latent rather than broken — their Pages projects already exist, so `ensure-cf-project` is a no-op and prune always finds its target. Left out of scope here; worth a follow-up so the next new Pages app does not hit this.

## Test plan

- [x] `nx show project docs-md` confirms `prune-deployments` → `ensure-cf-project` in the target graph
- [x] Pre-commit hooks pass
- [ ] `deploy` workflow on merge to `main` runs `docs-md:deploy` green
- [ ] `terraform apply` reconciles `cloudflare_pages_domain.docs` without the 404
- [ ] `https://docs.harryliu.dev/` serves, and the Upptime check in `.upptimerc.yml` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)