### PR TITLE
fix(personal-website-react): Close dark mode, badge, and contact form gaps with the Angular app.

### DIFF
--- a/projects/nx-workspace/apps/ui/personal-website-react/src/app/components/features/contact-section.tsx
+++ b/projects/nx-workspace/apps/ui/personal-website-react/src/app/components/features/contact-section.tsx
@@ -7,6 +7,40 @@ import {
 import { getRecaptchaToken, useRecaptcha } from '../../core/services/recaptcha';
 
 const APP_NAME_HARRYLIU_DESIGN = 'harryliu-design';
+const RECAPTCHA_ACTION = 'contact';
+const HEADER_TEXT = 'Message Me';
+const SOCIAL_MEDIAS_HEADER = 'Social Medias';
+const SUBMITTED_TEXT = "Message received! I'll get back to you soon.";
+const SUBMIT_BUTTON_TEXT = 'Submit';
+const INVALID_EMAIL_TEXT = 'Please enter a valid email address.';
+const UNKNOWN_ERROR_TEXT = 'Something went wrong. Please try again.';
+
+const FIELDS = {
+  NAME: {
+    ID: 'contact-form-name-input',
+    NAME: 'name',
+    LABEL: 'Name:',
+    AUTOCOMPLETE: 'given-name',
+  },
+  EMAIL: {
+    ID: 'contact-form-email-input',
+    NAME: 'email',
+    LABEL: 'Email:',
+    AUTOCOMPLETE: 'email',
+  },
+  MESSAGE: {
+    ID: 'contact-form-message-input',
+    NAME: 'message',
+    LABEL: 'Message:',
+  },
+} as const;
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const INPUT_CLASSES =
+  'w-full px-3 py-2 border rounded-lg shadow-sm focus:outline-none focus:ring focus:border-blue-300 dark:bg-gray-800';
+const INPUT_BORDER_CLASSES = 'dark:border-gray-700';
+const INPUT_ERROR_BORDER_CLASSES = 'border-red-500 dark:border-red-500';
 
 const CONTACT_LINKS = [
   LINKS.LINKEDIN,
@@ -20,95 +54,167 @@ export function ContactSection() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [message, setMessage] = useState('');
-  const [submitting, setSubmitting] = useState(false);
+  const [emailDirty, setEmailDirty] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [submitError, setSubmitError] = useState('');
 
-  const onSubmit = async (e: FormEvent) => {
-    e.preventDefault();
-    if (!name.trim() || !email.trim() || !message.trim()) return;
-    setSubmitting(true);
+  const emailInvalid = !EMAIL_PATTERN.test(email);
+  const formInvalid = !name.trim() || emailInvalid || !message.trim();
+  const showEmailError = emailInvalid && emailDirty;
+  const disabled = formInvalid || loading;
+
+  const submitForm = async (event: FormEvent) => {
+    event.preventDefault();
+    if (disabled) return;
+    setLoading(true);
+    setSubmitError('');
     try {
-      const recaptchaToken = await getRecaptchaToken('contact');
-      const req: MessageRequest = {
+      const recaptchaToken = await getRecaptchaToken(RECAPTCHA_ACTION);
+      const request: MessageRequest = {
         name,
         email,
         message,
         appName: APP_NAME_HARRYLIU_DESIGN,
         recaptchaToken,
       };
-      await sendMessage(req);
+      await sendMessage(request);
       setName('');
       setEmail('');
       setMessage('');
-    } catch {
-      // error already surfaced
+      setEmailDirty(false);
+      setSubmitted(true);
+    } catch (error) {
+      setSubmitError(
+        error instanceof Error ? error.message : UNKNOWN_ERROR_TEXT,
+      );
     } finally {
-      setSubmitting(false);
+      setLoading(false);
     }
   };
 
+  const buttonStateClasses = [
+    disabled ? 'bg-gray-300' : 'bg-black hover:bg-blue-600',
+    loading ? 'cursor-not-allowed' : '',
+  ].join(' ');
+
   return (
-    <div>
-      <h2 className="text-2xl font-bold mb-4">Message Me</h2>
-      <form onSubmit={onSubmit} className="space-y-4 mb-6">
-        <div>
-          <label className="block text-sm mb-1" htmlFor="contact-name">
-            Name
-          </label>
-          <input
-            id="contact-name"
-            type="text"
-            value={name}
-            onChange={e => setName(e.target.value)}
-            required
-            className="w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
+    <div className="grid lg:grid-cols-2">
+      <div className="w-11/12 lg:w-5/6 mx-auto text-sm">
+        <h2 className="text-md font-semibold mb-4 text-center lg:text-left">
+          {HEADER_TEXT}
+        </h2>
+        {submitted ? (
+          <p className="text-green-600">{SUBMITTED_TEXT}</p>
+        ) : (
+          <form onSubmit={submitForm}>
+            <div className="mb-4">
+              <label htmlFor={FIELDS.NAME.ID} className="block">
+                {FIELDS.NAME.LABEL}
+              </label>
+              <input
+                type="text"
+                id={FIELDS.NAME.ID}
+                name={FIELDS.NAME.NAME}
+                autoComplete={FIELDS.NAME.AUTOCOMPLETE}
+                required
+                value={name}
+                onChange={event => setName(event.target.value)}
+                className={`${INPUT_CLASSES} ${INPUT_BORDER_CLASSES}`}
+              />
+            </div>
+            <div className="mb-4">
+              <label htmlFor={FIELDS.EMAIL.ID} className="block">
+                {FIELDS.EMAIL.LABEL}
+              </label>
+              <input
+                type="email"
+                id={FIELDS.EMAIL.ID}
+                name={FIELDS.EMAIL.NAME}
+                autoComplete={FIELDS.EMAIL.AUTOCOMPLETE}
+                required
+                value={email}
+                onChange={event => {
+                  setEmail(event.target.value);
+                  setEmailDirty(true);
+                }}
+                className={`${INPUT_CLASSES} ${
+                  showEmailError
+                    ? INPUT_ERROR_BORDER_CLASSES
+                    : INPUT_BORDER_CLASSES
+                }`}
+              />
+              {showEmailError && (
+                <p className="text-red-500 text-xs mt-1">
+                  {INVALID_EMAIL_TEXT}
+                </p>
+              )}
+            </div>
+            <div className="mb-4">
+              <label htmlFor={FIELDS.MESSAGE.ID} className="block">
+                {FIELDS.MESSAGE.LABEL}
+              </label>
+              <textarea
+                id={FIELDS.MESSAGE.ID}
+                name={FIELDS.MESSAGE.NAME}
+                required
+                value={message}
+                onChange={event => setMessage(event.target.value)}
+                className={`${INPUT_CLASSES} ${INPUT_BORDER_CLASSES}`}
+              />
+            </div>
+            {submitError && (
+              <p role="alert" className="text-red-500 text-xs mb-4">
+                {submitError}
+              </p>
+            )}
+            <button
+              type="submit"
+              disabled={disabled}
+              className={`text-white font-semibold py-2 rounded-lg focus:outline-none focus:ring w-full lg:w-auto lg:min-w-28 flex items-center justify-center ${buttonStateClasses}`}
+            >
+              {loading ? (
+                <svg
+                  className="animate-spin h-5 w-5 text-white"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C6.477 0 2 4.477 2 10h2zm2 5.292A7.952 7.952 0 014 12H2c0 3.866 2.239 7.155 5.292 8.708l1.416-1.416z"
+                  />
+                </svg>
+              ) : (
+                SUBMIT_BUTTON_TEXT
+              )}
+            </button>
+          </form>
+        )}
+      </div>
+      <hr className="lg:hidden mt-8 mb-8" />
+      <div className="w-11/12 lg:w-5/6 mx-auto text-center lg:text-left">
+        <div className="mb-4">
+          <h1 className="mb-2 text-md font-semibold">{SOCIAL_MEDIAS_HEADER}</h1>
+          <ul>
+            {CONTACT_LINKS.map(link => (
+              <li key={link.text}>
+                <a href={link.url.external} target="_blank" rel="noreferrer">
+                  {link.text}
+                </a>
+              </li>
+            ))}
+          </ul>
         </div>
-        <div>
-          <label className="block text-sm mb-1" htmlFor="contact-email">
-            Email
-          </label>
-          <input
-            id="contact-email"
-            type="email"
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-            required
-            className="w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-        </div>
-        <div>
-          <label className="block text-sm mb-1" htmlFor="contact-message">
-            Message
-          </label>
-          <textarea
-            id="contact-message"
-            value={message}
-            onChange={e => setMessage(e.target.value)}
-            rows={5}
-            required
-            className="w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
-        </div>
-        <button
-          type="submit"
-          disabled={submitting}
-          className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
-        >
-          {submitting ? 'Sending...' : 'Send'}
-        </button>
-      </form>
-      <div className="flex flex-wrap gap-3">
-        {CONTACT_LINKS.map(link => (
-          <a
-            key={link.text}
-            href={link.url.external}
-            target="_blank"
-            rel="noreferrer"
-            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
-          >
-            {link.text}
-          </a>
-        ))}
       </div>
     </div>
   );

--- a/projects/nx-workspace/apps/ui/personal-website-react/src/app/components/global/markdown-page.tsx
+++ b/projects/nx-workspace/apps/ui/personal-website-react/src/app/components/global/markdown-page.tsx
@@ -36,7 +36,7 @@ export function MarkdownPage({ filepath }: Props) {
   if (html === null) return <LoadingSpinner header="Loading..." />;
   return (
     <div
-      className="prose dark:prose-invert max-w-none prose-img:inline-block prose-img:my-0 prose-a:no-underline"
+      className="markdown-content prose dark:prose-invert max-w-none prose-img:inline-block prose-img:my-0 prose-a:no-underline"
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/projects/nx-workspace/apps/ui/personal-website-react/src/app/core/services/api.service.ts
+++ b/projects/nx-workspace/apps/ui/personal-website-react/src/app/core/services/api.service.ts
@@ -2,6 +2,11 @@ import { ENVIRONMENT } from '../../../environments/environment';
 
 const SEND_MESSAGE_ENDPOINT = '/api/send-message';
 
+const NETWORK_ERROR_MESSAGE =
+  "Couldn't reach the server. Check your connection and try again.";
+const SERVER_ERROR_MESSAGE =
+  'Something went wrong sending your message. Please try again, or reach out on one of the links here if it keeps failing.';
+
 export type MessageRequest = {
   name: string;
   email: string;
@@ -10,29 +15,18 @@ export type MessageRequest = {
   recaptchaToken?: string;
 };
 
-const showError = (msg: string) => alert(msg);
-const showSuccess = (msg: string) => alert(msg);
-
-export async function sendMessage(request: MessageRequest): Promise<any> {
-  try {
-    const res = await fetch(`${ENVIRONMENT.API_URL}${SEND_MESSAGE_ENDPOINT}`, {
+export async function sendMessage(request: MessageRequest): Promise<void> {
+  const response = await fetch(
+    `${ENVIRONMENT.API_URL}${SEND_MESSAGE_ENDPOINT}`,
+    {
       method: 'POST',
       credentials: 'include',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request),
-    });
-    if (!res.ok) {
-      const text = await res.text().catch(() => res.statusText);
-      showError(`This is a server side error:\n${text}`);
-      throw new Error(text);
-    }
-    const body = await res.json().catch(() => ({}));
-    if (body?.message) showSuccess(body.message);
-    return body;
-  } catch (err) {
-    if (err instanceof TypeError) {
-      showError(`This is a client side error: ${err.message}`);
-    }
-    throw err;
-  }
+    },
+  ).catch(() => {
+    throw new Error(NETWORK_ERROR_MESSAGE);
+  });
+
+  if (!response.ok) throw new Error(SERVER_ERROR_MESSAGE);
 }

--- a/projects/nx-workspace/apps/ui/personal-website-react/src/styles.scss
+++ b/projects/nx-workspace/apps/ui/personal-website-react/src/styles.scss
@@ -49,6 +49,23 @@ a:hover {
   visibility: hidden;
 }
 
+.markdown-content a img {
+  display: inline-block;
+  height: 1.5rem;
+  transition:
+    transform 0.2s ease,
+    filter 0.2s ease;
+}
+
+.markdown-content a img:hover {
+  transform: scale(1.1);
+  filter: brightness(1.15);
+}
+
+.markdown-content a:has(img):hover {
+  opacity: 1;
+}
+
 code {
   background-color: #f8f8f8;
   padding: 1em;

--- a/projects/nx-workspace/apps/ui/personal-website-react/tailwind.config.js
+++ b/projects/nx-workspace/apps/ui/personal-website-react/tailwind.config.js
@@ -5,6 +5,7 @@ const { join } = require('path');
 module.exports = {
   darkMode: 'class',
   content: [
+    join(__dirname, 'index.html'),
     join(
       __dirname,
       '{src,pages,components,app}/**/!(*.stories|*.spec).{ts,tsx,html}',


### PR DESCRIPTION
## Summary

Closes three parity gaps between `personal-website-react` and the Angular `personal-website-frontend` it is meant to replace.

- **Dark mode only applied to some components.** The Tailwind `content` glob (`{src,pages,components,app}/**`) never matched the app-root `index.html`, where `<body>` carries `dark:bg-zinc-900 dark:text-zinc-200`. Those two utilities were never generated, so the page background and base text stayed light while components using `dark:` classes inside `src/` darkened correctly. Angular's glob is `src/**/*.html`, which does include its `src/index.html`. Confirmed by compiling the CSS: `zinc-900` had 0 occurrences, `gray-900` had 1.
- **Markdown badges rendered small and non-interactive.** Angular's `md.scss` sizes them with `a img { height: 1.5rem }` and animates `scale(1.1)` + `brightness(1.15)` on hover. The React version relied on Tailwind `prose`, which renders images at natural size with no hover. Ported those rules under a `.markdown-content` class, plus `a:has(img):hover { opacity: 1 }` — the global `a:hover { opacity: 0.8 }` leaks into markdown in React (Angular's shadow DOM blocks it) and would have dimmed badges while they brightened.
- **Contact form was not a port of `lib-contact`.** Rewrote it against `libs/angular/general-components/src/lib/contact/`: two-column `lg:grid-cols-2` layout with the form left and a "Social Medias" list right, mobile `<hr>` divider, `Name:`/`Email:`/`Message:` labels, email regex validation with red border + error text on dirty, black Submit button with spinner SVG, and the success state replacing the form.
- **Replaced `alert()` with inline error rendering.** `api.service.ts` now throws user-facing errors instead of alerting; the form renders them in red above Submit with `role="alert"`. Previously a failed send popped an alert and, once dismissed, left the user staring at a form with no indication anything was wrong. Return type went `Promise<any>` → `Promise<void>` since the only use of the parsed body was the alert.

## Test plan

- [x] `nx build personal-website-react` and `nx lint personal-website-react` pass; `tsc --noEmit` clean
- [x] Built CSS contains `.dark\:bg-zinc-900` / `.dark\:text-zinc-200` (absent before)
- [x] Body background matches Angular exactly in dark (`rgb(24,24,27)`) and light (`rgb(255,255,255)`), verified with both apps served side by side
- [x] Badge computed style identical across apps: `24px`, `inline-block`, `scale(1.1)` + `brightness(1.15)` on hover, link opacity stays `1`
- [x] Contact layout pixel-identical at 1280px; stacks with `<hr>` visible at 420px
- [x] Submit button states match Angular in all three phases — empty `rgb(209,213,219)` disabled, valid `rgb(0,0,0)` pointer, loading `rgb(209,213,219)` `not-allowed` with spinner (caught a real bug here: loading was rendering black because a nested ternary checked `loading` before `formInvalid`, whereas Angular passes `disabled = form.invalid || loading`)
- [x] Email validation: red border `rgb(239,68,68)` when invalid and blurred, neutral when valid, in both themes
- [x] Error paths driven with the network intercepted — server 500, network failure, success, and fail-then-retry all produce zero `alert()` dialogs; form contents survive a failure so the user can retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)