### PR TITLE
fix(personal-website-react): Post contact messages to the endpoint vb-express actually serves.

### DIFF
--- a/projects/nx-workspace/apps/ui/personal-website-react/src/app/core/services/api.service.ts
+++ b/projects/nx-workspace/apps/ui/personal-website-react/src/app/core/services/api.service.ts
@@ -1,6 +1,5 @@
+import { PERSONAL_WEBSITE_BACKEND_ENDPOINTS } from '@vigilant-broccoli/personal-common-js';
 import { ENVIRONMENT } from '../../../environments/environment';
-
-const SEND_MESSAGE_ENDPOINT = '/api/send-message';
 
 const NETWORK_ERROR_MESSAGE =
   "Couldn't reach the server. Check your connection and try again.";
@@ -17,7 +16,7 @@ export type MessageRequest = {
 
 export async function sendMessage(request: MessageRequest): Promise<void> {
   const response = await fetch(
-    `${ENVIRONMENT.API_URL}${SEND_MESSAGE_ENDPOINT}`,
+    `${ENVIRONMENT.API_URL}${PERSONAL_WEBSITE_BACKEND_ENDPOINTS.SEND_MESSAGE}`,
     {
       method: 'POST',
       credentials: 'include',


### PR DESCRIPTION
## Summary

The contact form on the newly-live `harryliu.dev` 404s on every submission.

- `api.service.ts` hardcoded `/api/send-message`, but `vb-express` registers `contactRoutes` under a `/contact` prefix (`apps/api/vb-express/src/main.ts:83-89`), making the real path `/contact/send-message`. The server response was literally `{"message":"Route POST:/api/send-message not found","statusCode":404}`.
- The Angular app never had this bug — it used `PERSONAL_WEBSITE_BACKEND_ENDPOINTS.SEND_MESSAGE` from `@vigilant-broccoli/personal-common-js`, which is already `/contact/send-message`. The React rewrite substituted a local literal and drifted.
- Fixed by importing that shared const, per the repo convention of preferring shared consts over local equivalents. This also means the path can't drift from the server again.

Pre-existing bug in the React app, not introduced by the cutover — but the cutover is what put it in front of real visitors.

## Test plan

- [x] Probed the live API: `POST /api/send-message` → `404 Route not found`; `POST /contact/send-message` → `403` from the recaptcha guard, proving the route exists and is reached
- [x] `tsc --noEmit`, `nx lint`, and `nx build personal-website-react` all pass
- [x] Built bundle contains `/contact/send-message` and no longer contains `/api/send-message`
- [ ] After deploy, submit the form on `harryliu.dev/contact` and confirm the success state instead of the inline error

🤖 Generated with [Claude Code](https://claude.com/claude-code)