### PR TITLE
refactor(agent-sandbox): Drive TODO solves with a deterministic runner script

### DIFF
--- a/infrastructure/agent-sandbox/solve-todo-runner.sh
+++ b/infrastructure/agent-sandbox/solve-todo-runner.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -euo pipefail
+
+ID=${1:?Usage: solve-todo-runner.sh <TODO_ID>}
+MODEL=${SOLVE_MODEL:-sonnet}
+REPO_DIR="$HOME/vigilant-broccoli"
+META_FILE=/tmp/solve-meta.json
+BRANCH="agent/todo-${ID}"
+PR_FOOTER='🤖 Generated with [Claude Code](https://claude.com/claude-code)'
+FALLBACK_TRAILER='Co-authored-by: Claude <noreply@anthropic.com>'
+
+cd "$REPO_DIR"
+
+ITEM=$(awk -v id="$ID" '/^### /||/^## /{p=($0 ~ "^### " id "\\.")} p' TODO.md)
+if [ -z "$ITEM" ]; then
+  echo "ERROR: no '### ${ID}.' item in TODO.md" >&2
+  exit 1
+fi
+
+git checkout -b "$BRANCH"
+BASE_SHA=$(git rev-parse HEAD)
+rm -f "$META_FILE"
+
+PROMPT=$(cat <<EOF
+You are running non-interactively in a fresh clone of vigilant-broccoli, on a dedicated branch. Resolve this TODO item (already extracted from the repo root TODO.md):
+
+$ITEM
+
+Rules:
+- Make only the changes needed to resolve the item, following the repo conventions in CLAUDE.md.
+- Do not run any git or gh commands and do not edit TODO.md — branching, TODO.md cleanup, committing, pushing, and opening the PR are all handled by the calling script.
+- When finished, write $META_FILE containing only a JSON object with these string fields:
+  - commit_type: one of feat, fix, ci, chore, docs, refactor, enhancement, security, infrastructure
+  - commit_scope: the affected app/service/lib name, or "" when the change is not scoped to one
+  - commit_message: capitalized, concise, focused on why not what, ending with a period
+  - co_authored_by: the Co-Authored-By trailer line specified by your environment for the model authoring the commit
+  - pr_title: the pull request title
+  - pr_summary: markdown bullet points for the PR "## Summary" section
+  - pr_test_plan: markdown checklist for the PR "## Test plan" section
+EOF
+)
+
+claude -p "$PROMPT" --dangerously-skip-permissions --model "$MODEL" \
+  --disallowedTools "Bash(git commit:*)" "Bash(git push:*)" "Bash(git checkout:*)" "Bash(git switch:*)" "Bash(gh:*)"
+
+git checkout "$BRANCH"
+[ "$(git rev-parse HEAD)" = "$BASE_SHA" ] || git reset --soft "$BASE_SHA"
+
+if [ -z "$(git status --porcelain -- ':(exclude)TODO.md')" ]; then
+  echo "ERROR: no changes besides TODO.md — TODO ${ID} was not resolved." >&2
+  exit 1
+fi
+
+TMP=$(mktemp)
+awk -v id="$ID" '/^### /||/^## /{skip=($0 ~ "^### " id "\\.")} !skip' TODO.md > "$TMP"
+awk '
+  function flush() { if (heading == "" || has_item) { if (heading != "") print heading; printf "%s", buf } }
+  /^## / { flush(); heading = $0; buf = ""; has_item = 0; next }
+  { buf = buf $0 "\n"; if (/^### /) has_item = 1 }
+  END { flush() }
+' "$TMP" > TODO.md
+rm -f "$TMP"
+
+read_meta() { jq -r "$1 // empty" "$META_FILE" 2>/dev/null || true; }
+
+COMMIT_TYPE=$(read_meta .commit_type)
+COMMIT_SCOPE=$(read_meta .commit_scope)
+COMMIT_MESSAGE=$(read_meta .commit_message)
+TRAILER=$(read_meta .co_authored_by)
+PR_TITLE=$(read_meta .pr_title)
+PR_SUMMARY=$(read_meta .pr_summary)
+PR_TEST_PLAN=$(read_meta .pr_test_plan)
+
+case "$COMMIT_TYPE" in
+  feat | fix | ci | chore | docs | refactor | enhancement | security | infrastructure) ;;
+  *) COMMIT_TYPE="" ;;
+esac
+
+if [ -n "$COMMIT_TYPE" ] && [ -n "$COMMIT_MESSAGE" ]; then
+  if [ -n "$COMMIT_SCOPE" ]; then
+    COMMIT_SUBJECT="${COMMIT_TYPE}(${COMMIT_SCOPE}): ${COMMIT_MESSAGE}"
+  else
+    COMMIT_SUBJECT="${COMMIT_TYPE}: ${COMMIT_MESSAGE}"
+  fi
+else
+  COMMIT_SUBJECT="chore: Resolve TODO ${ID}."
+fi
+
+echo "$TRAILER" | grep -Eqi '^co-authored-by: .+ <.+>$' || TRAILER="$FALLBACK_TRAILER"
+[ -n "$PR_TITLE" ] || PR_TITLE="$COMMIT_SUBJECT"
+[ -n "$PR_SUMMARY" ] || PR_SUMMARY="- Resolve TODO ${ID}."
+[ -n "$PR_TEST_PLAN" ] || PR_TEST_PLAN="- [ ] CI passes"
+
+git add -A
+git commit -m "$COMMIT_SUBJECT" -m "$TRAILER"
+git push -u origin "$BRANCH"
+
+PR_BODY=$(cat <<EOF
+## Summary
+
+$PR_SUMMARY
+
+## Test plan
+
+$PR_TEST_PLAN
+
+$PR_FOOTER
+EOF
+)
+
+gh pr create --title "$PR_TITLE" --body "$PR_BODY"

--- a/infrastructure/agent-sandbox/solve-todo.sh
+++ b/infrastructure/agent-sandbox/solve-todo.sh
@@ -51,18 +51,6 @@ fi
 LOG_DIR=$(mktemp -d /tmp/vb-solve.XXXXXX)
 echo "Logs: $LOG_DIR"
 
-solve_prompt() {
-  cat <<EOF
-You are running non-interactively in a fresh clone of vigilant-broccoli. Solve TODO item $1:
-
-1. Read TODO.md at the repo root and find the item under the heading starting with "### $1.". If no such item exists, print an error and exit non-zero without making changes.
-2. Resolve the issue described by that item.
-3. Remove the resolved item from TODO.md (and its priority heading, e.g. "## P2", if it has no items left).
-4. Invoke the /git-workflow command (instructions in ~/.claude/commands/git-workflow.md) to branch, commit, push, and open a PR that includes both the fix and the TODO.md update.
-5. Print the PR URL.
-EOF
-}
-
 PIDS=()
 for id in "${IDS[@]}"; do
   grep -q "^### ${id}\." "$REPO_ROOT/TODO.md" || echo "WARNING: no '### ${id}.' item in local TODO.md (sandbox clones fresh main)" >&2
@@ -70,10 +58,9 @@ for id in "${IDS[@]}"; do
     --cap-add NET_ADMIN --cap-add NET_RAW \
     --env-file "$ENV_FILE" \
     -e GH_TOKEN="$GH_TOKEN_VALUE" \
-    -e SOLVE_PROMPT="$(solve_prompt "$id")" \
     -e SOLVE_MODEL="$MODEL" \
     "$IMAGE" \
-    bash -c 'cd "$HOME/vigilant-broccoli" && exec claude -p "$SOLVE_PROMPT" --dangerously-skip-permissions --model "$SOLVE_MODEL"' \
+    bash -c 'exec bash "$HOME/vigilant-broccoli/infrastructure/agent-sandbox/solve-todo-runner.sh" "$1"' _ "$id" \
     > "$LOG_DIR/solve-${id}.log" 2>&1 &
   PIDS+=($!)
   echo "Started vb-solve-${id} (model: $MODEL, log: $LOG_DIR/solve-${id}.log)"


### PR DESCRIPTION
## Summary
- Add `infrastructure/agent-sandbox/solve-todo-runner.sh`: the in-container pipeline for `pnpm agentic:task:solve` that keeps only code authoring and commit/PR copy LLM-generated, and does everything else programmatically — TODO item extraction (fail-fast if the ID is missing), branch creation (`agent/todo-<id>`), TODO.md item removal with emptied-priority-heading cleanup, staging, commit, push, and `gh pr create`.
- The `claude -p` call is narrowed to "resolve this item and write a meta JSON" (`commit_type`/`commit_scope`/`commit_message`/`co_authored_by`/`pr_title`/`pr_summary`/`pr_test_plan`); git/gh usage is blocked via `--disallowedTools`, a post-run `git reset --soft` guard reverts any stray commits, and jq-validated fallbacks cover malformed meta output.
- Runs now fail deterministically when nothing besides TODO.md changed, and the PR URL comes from `gh pr create` output instead of hoping the agent prints one.
- `solve-todo.sh` now invokes the runner from the sandbox's fresh clone instead of shipping the five-step agentic prompt (note: solve runs pick the runner up from `main`, so it takes effect once this merges).

## Test plan
- [x] `bash -n` passes on both scripts
- [x] awk extraction/removal verified against the real `TODO.md` (single item removal, emptied `## P1` heading cleanup, no double blank lines, missing ID → error)
- [x] Meta parsing verified for valid, invalid-type, non-JSON, and missing meta files (deterministic `chore: Resolve TODO <id>.` fallback)
- [ ] Run `pnpm agentic:task:solve <id>` on a real TODO item after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)