### PR TITLE
feat(agent-sandbox): Add agentic:task:create, and a free-text --prompt mode for agentic:task:solve.

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -92,6 +92,7 @@ Useful infra-level CLI commands, runnable via `pnpm run <script>`.
 
 🚀 AGENTIC — TASKS (unattended; ephemeral containers, no human in the loop)
   agentic:task:solve <id...>  Headlessly solve TODO.md item(s) in parallel ephemeral sandbox containers; each opens a PR via /git-workflow (sonnet; --model <m> to override)
+  agentic:task:create <desc>  Headlessly research and add a TODO.md entry for <desc> in an ephemeral sandbox container, then open a PR (sonnet; --model <m> to override)
 
 🏠 HOMELAB
   homelab:up                  Start homelab services and Tailscale

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -91,7 +91,8 @@ Useful infra-level CLI commands, runnable via `pnpm run <script>`.
   agentic:dev-sandbox:reset   Destroy sandbox volume and rebuild fresh
 
 🚀 AGENTIC — TASKS (unattended; ephemeral containers, no human in the loop)
-  agentic:task:solve <id...>  Headlessly solve TODO.md item(s) in parallel ephemeral sandbox containers; each opens a PR via /git-workflow (sonnet; --model <m> to override)
+  agentic:task:solve <id...>  Headlessly solve TODO.md item(s) in parallel ephemeral sandbox containers; each opens a PR (sonnet; --model <m> to override)
+                               (or --prompt "<task>" to solve a free-text task instead of TODO ids, e.g. "add a /health route to vb-express")
   agentic:task:create <desc>  Headlessly research and add a TODO.md entry for <desc> in an ephemeral sandbox container, then open a PR (sonnet; --model <m> to override)
 
 🏠 HOMELAB

--- a/infrastructure/agent-sandbox/create-todo-runner.sh
+++ b/infrastructure/agent-sandbox/create-todo-runner.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+set -euo pipefail
+
+DESCRIPTION=${1:?Usage: create-todo-runner.sh <DESCRIPTION>}
+MODEL=${SOLVE_MODEL:-sonnet}
+REPO_DIR="$HOME/vigilant-broccoli"
+META_FILE=/tmp/create-meta.json
+SLUG=$(echo "$DESCRIPTION" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//' | cut -c1-40)
+BRANCH="agent/todo-create-${SLUG:-task}-$(date +%s)"
+PR_FOOTER='🤖 Generated with [Claude Code](https://claude.com/claude-code)'
+FALLBACK_TRAILER='Co-authored-by: Claude <noreply@anthropic.com>'
+
+cd "$REPO_DIR"
+
+git checkout -b "$BRANCH"
+BASE_SHA=$(git rev-parse HEAD)
+rm -f "$META_FILE"
+
+PROMPT=$(cat <<EOF
+You are running non-interactively in a fresh clone of vigilant-broccoli, on a dedicated branch. Create a well-researched task entry in the repo root TODO.md for the following:
+
+$DESCRIPTION
+
+Rules:
+- Read TODO.md to learn its structure: section headings (## Features to Add, ## P1-P3) and entry format: ### <6-hex-id>. [category] Title, a short context paragraph, then a numbered Steps: list.
+- Research before writing: grep the repo for every file, workflow, config, and doc the task touches. The entry must cite concrete paths (with line numbers where useful) and name an existing pattern to follow when one exists.
+- Check CLAUDE.md and the docs it points to for conventions that constrain the task, and bake them into the steps.
+- Generate a unique 6-hex id (python3 -c "import random; print(format(random.randint(0, 0xffffff), '06x'))") and verify it doesn't already appear in TODO.md.
+- Add the entry under the most fitting existing section; only create a new section if none fits.
+- Do not implement the task. Do not touch any file besides TODO.md.
+- Do not run any git or gh commands and do not commit — branching, committing, pushing, and opening the PR are handled by the calling script.
+- When finished, write $META_FILE containing only a JSON object with these string fields:
+  - todo_id: the 6-hex id you generated
+  - commit_message: capitalized, concise, focused on why the entry is needed, ending with a period
+  - co_authored_by: the Co-Authored-By trailer line specified by your environment for the model authoring the commit
+  - pr_title: the pull request title
+  - pr_summary: markdown bullet points for the PR "## Summary" section
+  - pr_test_plan: markdown checklist for the PR "## Test plan" section
+EOF
+)
+
+claude -p "$PROMPT" --dangerously-skip-permissions --model "$MODEL" \
+  --disallowedTools "Bash(git commit:*)" "Bash(git push:*)" "Bash(git checkout:*)" "Bash(git switch:*)" "Bash(gh:*)"
+
+git checkout "$BRANCH"
+[ "$(git rev-parse HEAD)" = "$BASE_SHA" ] || git reset --soft "$BASE_SHA"
+
+if [ -z "$(git status --porcelain -- TODO.md)" ]; then
+  echo "ERROR: TODO.md was not modified — no entry was added." >&2
+  exit 1
+fi
+if [ -n "$(git status --porcelain -- ':(exclude)TODO.md')" ]; then
+  echo "ERROR: changes outside TODO.md were made; only TODO.md should change." >&2
+  git status --porcelain >&2
+  exit 1
+fi
+
+read_meta() { jq -r "$1 // empty" "$META_FILE" 2>/dev/null || true; }
+
+TODO_ID=$(read_meta .todo_id)
+COMMIT_MESSAGE=$(read_meta .commit_message)
+TRAILER=$(read_meta .co_authored_by)
+PR_TITLE=$(read_meta .pr_title)
+PR_SUMMARY=$(read_meta .pr_summary)
+PR_TEST_PLAN=$(read_meta .pr_test_plan)
+
+if [ -n "$COMMIT_MESSAGE" ]; then
+  COMMIT_SUBJECT="docs: ${COMMIT_MESSAGE}"
+else
+  COMMIT_SUBJECT="docs: Add TODO entry for ${DESCRIPTION}."
+fi
+
+echo "$TRAILER" | grep -Eqi '^co-authored-by: .+ <.+>$' || TRAILER="$FALLBACK_TRAILER"
+[ -n "$PR_TITLE" ] || PR_TITLE="$COMMIT_SUBJECT"
+[ -n "$PR_SUMMARY" ] || PR_SUMMARY="- Add TODO entry${TODO_ID:+ ${TODO_ID}} for: ${DESCRIPTION}"
+[ -n "$PR_TEST_PLAN" ] || PR_TEST_PLAN="- [ ] Entry reviewed for accuracy and actionable steps"
+
+git add TODO.md
+git commit -m "$COMMIT_SUBJECT" -m "$TRAILER"
+git push -u origin "$BRANCH"
+
+PR_BODY=$(cat <<EOF
+## Summary
+
+$PR_SUMMARY
+
+## Test plan
+
+$PR_TEST_PLAN
+
+$PR_FOOTER
+EOF
+)
+
+gh pr create --title "$PR_TITLE" --body "$PR_BODY"

--- a/infrastructure/agent-sandbox/create-todo.sh
+++ b/infrastructure/agent-sandbox/create-todo.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+IMAGE=vb-agent-sandbox
+
+MODEL=sonnet
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --model)
+      MODEL=$2
+      shift 2
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+DESCRIPTION="${ARGS[*]:-}"
+if [ -z "$DESCRIPTION" ]; then
+  echo "Usage: pnpm agentic:task:create [--model <model>] <description>" >&2
+  exit 1
+fi
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  docker compose -f "$SCRIPT_DIR/docker-compose.yml" build
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  "$SCRIPT_DIR/load-env-from-vault.sh"
+fi
+
+GH_TOKEN_VALUE=$(grep '^GH_TOKEN=' "$ENV_FILE" | cut -d= -f2-)
+APP_ID=$(grep '^AGENT_GH_APP_ID=' "$ENV_FILE" | cut -d= -f2-)
+PEM_FILE="$SCRIPT_DIR/.github-app-key.pem"
+if [ -n "$APP_ID" ] && [ -f "$PEM_FILE" ]; then
+  echo "Minting fresh GitHub App installation token..."
+  GH_TOKEN_VALUE=$("$SCRIPT_DIR/mint-github-app-token.sh" "$APP_ID" "$PEM_FILE")
+fi
+
+if [ -z "$GH_TOKEN_VALUE" ]; then
+  echo "ERROR: no GitHub token available — this cannot push or open a PR." >&2
+  echo "Add GitHub App credentials or a fine-grained PAT to Vault (see docs/infrastructure/secret-management.md), then run: pnpm agentic:dev-sandbox:up" >&2
+  exit 1
+fi
+
+echo "Creating TODO entry for: $DESCRIPTION"
+docker run --rm --init --name "vb-create-$(date +%s)" \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  --env-file "$ENV_FILE" \
+  -e GH_TOKEN="$GH_TOKEN_VALUE" \
+  -e SOLVE_MODEL="$MODEL" \
+  "$IMAGE" \
+  bash -c 'exec bash "$HOME/vigilant-broccoli/infrastructure/agent-sandbox/create-todo-runner.sh" "$1"' _ "$DESCRIPTION"

--- a/infrastructure/agent-sandbox/solve-todo-runner.sh
+++ b/infrastructure/agent-sandbox/solve-todo-runner.sh
@@ -1,19 +1,52 @@
 #!/bin/bash
 set -euo pipefail
 
-ID=${1:?Usage: solve-todo-runner.sh <TODO_ID>}
+MODE=""
+ID=""
+TASK=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --id)
+      MODE=id
+      ID=$2
+      shift 2
+      ;;
+    --prompt)
+      MODE=prompt
+      TASK=$2
+      shift 2
+      ;;
+    *)
+      echo "Usage: solve-todo-runner.sh (--id <TODO_ID> | --prompt <text>)" >&2
+      exit 1
+      ;;
+  esac
+done
+
 MODEL=${SOLVE_MODEL:-sonnet}
 REPO_DIR="$HOME/vigilant-broccoli"
 META_FILE=/tmp/solve-meta.json
-BRANCH="agent/todo-${ID}"
 PR_FOOTER='🤖 Generated with [Claude Code](https://claude.com/claude-code)'
 FALLBACK_TRAILER='Co-authored-by: Claude <noreply@anthropic.com>'
 
 cd "$REPO_DIR"
 
-ITEM=$(awk -v id="$ID" '/^### /||/^## /{p=($0 ~ "^### " id "\\.")} p' TODO.md)
-if [ -z "$ITEM" ]; then
-  echo "ERROR: no '### ${ID}.' item in TODO.md" >&2
+if [ "$MODE" = id ]; then
+  TASK=$(awk -v id="$ID" '/^### /||/^## /{p=($0 ~ "^### " id "\\.")} p' TODO.md)
+  if [ -z "$TASK" ]; then
+    echo "ERROR: no '### ${ID}.' item in TODO.md" >&2
+    exit 1
+  fi
+  BRANCH="agent/todo-${ID}"
+  INTRO="Resolve this TODO item (already extracted from the repo root TODO.md):"
+  SCOPE_RULE="- Do not run any git or gh commands and do not edit TODO.md — branching, TODO.md cleanup, committing, pushing, and opening the PR are all handled by the calling script."
+elif [ "$MODE" = prompt ]; then
+  SLUG=$(echo "$TASK" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' '-' | sed 's/^-*//;s/-*$//' | cut -c1-40)
+  BRANCH="agent/task-${SLUG:-task}-$(date +%s)"
+  INTRO="Accomplish this task:"
+  SCOPE_RULE="- Do not run any git or gh commands — branching, committing, pushing, and opening the PR are all handled by the calling script."
+else
+  echo "Usage: solve-todo-runner.sh (--id <TODO_ID> | --prompt <text>)" >&2
   exit 1
 fi
 
@@ -22,13 +55,13 @@ BASE_SHA=$(git rev-parse HEAD)
 rm -f "$META_FILE"
 
 PROMPT=$(cat <<EOF
-You are running non-interactively in a fresh clone of vigilant-broccoli, on a dedicated branch. Resolve this TODO item (already extracted from the repo root TODO.md):
+You are running non-interactively in a fresh clone of vigilant-broccoli, on a dedicated branch. $INTRO
 
-$ITEM
+$TASK
 
 Rules:
-- Make only the changes needed to resolve the item, following the repo conventions in CLAUDE.md.
-- Do not run any git or gh commands and do not edit TODO.md — branching, TODO.md cleanup, committing, pushing, and opening the PR are all handled by the calling script.
+- Make only the changes needed, following the repo conventions in CLAUDE.md.
+$SCOPE_RULE
 - When finished, write $META_FILE containing only a JSON object with these string fields:
   - commit_type: one of feat, fix, ci, chore, docs, refactor, enhancement, security, infrastructure
   - commit_scope: the affected app/service/lib name, or "" when the change is not scoped to one
@@ -46,20 +79,26 @@ claude -p "$PROMPT" --dangerously-skip-permissions --model "$MODEL" \
 git checkout "$BRANCH"
 [ "$(git rev-parse HEAD)" = "$BASE_SHA" ] || git reset --soft "$BASE_SHA"
 
-if [ -z "$(git status --porcelain -- ':(exclude)TODO.md')" ]; then
-  echo "ERROR: no changes besides TODO.md — TODO ${ID} was not resolved." >&2
-  exit 1
+if [ "$MODE" = id ]; then
+  if [ -z "$(git status --porcelain -- ':(exclude)TODO.md')" ]; then
+    echo "ERROR: no changes besides TODO.md — TODO ${ID} was not resolved." >&2
+    exit 1
+  fi
+  TMP=$(mktemp)
+  awk -v id="$ID" '/^### /||/^## /{skip=($0 ~ "^### " id "\\.")} !skip' TODO.md > "$TMP"
+  awk '
+    function flush() { if (heading == "" || has_item) { if (heading != "") print heading; printf "%s", buf } }
+    /^## / { flush(); heading = $0; buf = ""; has_item = 0; next }
+    { buf = buf $0 "\n"; if (/^### /) has_item = 1 }
+    END { flush() }
+  ' "$TMP" > TODO.md
+  rm -f "$TMP"
+else
+  if [ -z "$(git status --porcelain)" ]; then
+    echo "ERROR: no changes produced — task was not completed." >&2
+    exit 1
+  fi
 fi
-
-TMP=$(mktemp)
-awk -v id="$ID" '/^### /||/^## /{skip=($0 ~ "^### " id "\\.")} !skip' TODO.md > "$TMP"
-awk '
-  function flush() { if (heading == "" || has_item) { if (heading != "") print heading; printf "%s", buf } }
-  /^## / { flush(); heading = $0; buf = ""; has_item = 0; next }
-  { buf = buf $0 "\n"; if (/^### /) has_item = 1 }
-  END { flush() }
-' "$TMP" > TODO.md
-rm -f "$TMP"
 
 read_meta() { jq -r "$1 // empty" "$META_FILE" 2>/dev/null || true; }
 
@@ -76,6 +115,14 @@ case "$COMMIT_TYPE" in
   *) COMMIT_TYPE="" ;;
 esac
 
+if [ "$MODE" = id ]; then
+  FALLBACK_SUBJECT="chore: Resolve TODO ${ID}."
+  FALLBACK_SUMMARY="- Resolve TODO ${ID}."
+else
+  FALLBACK_SUBJECT="chore: Complete agent task."
+  FALLBACK_SUMMARY="- ${TASK}"
+fi
+
 if [ -n "$COMMIT_TYPE" ] && [ -n "$COMMIT_MESSAGE" ]; then
   if [ -n "$COMMIT_SCOPE" ]; then
     COMMIT_SUBJECT="${COMMIT_TYPE}(${COMMIT_SCOPE}): ${COMMIT_MESSAGE}"
@@ -83,12 +130,12 @@ if [ -n "$COMMIT_TYPE" ] && [ -n "$COMMIT_MESSAGE" ]; then
     COMMIT_SUBJECT="${COMMIT_TYPE}: ${COMMIT_MESSAGE}"
   fi
 else
-  COMMIT_SUBJECT="chore: Resolve TODO ${ID}."
+  COMMIT_SUBJECT="$FALLBACK_SUBJECT"
 fi
 
 echo "$TRAILER" | grep -Eqi '^co-authored-by: .+ <.+>$' || TRAILER="$FALLBACK_TRAILER"
 [ -n "$PR_TITLE" ] || PR_TITLE="$COMMIT_SUBJECT"
-[ -n "$PR_SUMMARY" ] || PR_SUMMARY="- Resolve TODO ${ID}."
+[ -n "$PR_SUMMARY" ] || PR_SUMMARY="$FALLBACK_SUMMARY"
 [ -n "$PR_TEST_PLAN" ] || PR_TEST_PLAN="- [ ] CI passes"
 
 git add -A

--- a/infrastructure/agent-sandbox/solve-todo.sh
+++ b/infrastructure/agent-sandbox/solve-todo.sh
@@ -7,11 +7,16 @@ ENV_FILE="$SCRIPT_DIR/.env"
 IMAGE=vb-agent-sandbox
 
 MODEL=sonnet
+PROMPT=""
 IDS=()
 while [ $# -gt 0 ]; do
   case "$1" in
     --model)
       MODEL=$2
+      shift 2
+      ;;
+    --prompt)
+      PROMPT=$2
       shift 2
       ;;
     *)
@@ -21,8 +26,12 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ ${#IDS[@]} -eq 0 ]; then
-  echo "Usage: pnpm agentic:task:solve [--model <model>] <TODO_ID> [TODO_ID...]" >&2
+if [ -n "$PROMPT" ] && [ ${#IDS[@]} -gt 0 ]; then
+  echo "ERROR: pass either --prompt \"<task>\" or TODO ids, not both." >&2
+  exit 1
+fi
+if [ -z "$PROMPT" ] && [ ${#IDS[@]} -eq 0 ]; then
+  echo "Usage: pnpm agentic:task:solve [--model <model>] (<TODO_ID> [TODO_ID...] | --prompt \"<task description>\")" >&2
   exit 1
 fi
 
@@ -48,6 +57,18 @@ if [ -z "$GH_TOKEN_VALUE" ]; then
   exit 1
 fi
 
+if [ -n "$PROMPT" ]; then
+  echo "Solving free-text task (model: $MODEL): $PROMPT"
+  docker run --rm --init --name "vb-solve-prompt-$(date +%s)" \
+    --cap-add NET_ADMIN --cap-add NET_RAW \
+    --env-file "$ENV_FILE" \
+    -e GH_TOKEN="$GH_TOKEN_VALUE" \
+    -e SOLVE_MODEL="$MODEL" \
+    "$IMAGE" \
+    bash -c 'exec bash "$HOME/vigilant-broccoli/infrastructure/agent-sandbox/solve-todo-runner.sh" --prompt "$1"' _ "$PROMPT"
+  exit $?
+fi
+
 LOG_DIR=$(mktemp -d /tmp/vb-solve.XXXXXX)
 echo "Logs: $LOG_DIR"
 
@@ -60,7 +81,7 @@ for id in "${IDS[@]}"; do
     -e GH_TOKEN="$GH_TOKEN_VALUE" \
     -e SOLVE_MODEL="$MODEL" \
     "$IMAGE" \
-    bash -c 'exec bash "$HOME/vigilant-broccoli/infrastructure/agent-sandbox/solve-todo-runner.sh" "$1"' _ "$id" \
+    bash -c 'exec bash "$HOME/vigilant-broccoli/infrastructure/agent-sandbox/solve-todo-runner.sh" --id "$1"' _ "$id" \
     > "$LOG_DIR/solve-${id}.log" 2>&1 &
   PIDS+=($!)
   echo "Started vb-solve-${id} (model: $MODEL, log: $LOG_DIR/solve-${id}.log)"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "agentic:dev-sandbox:down": "docker compose -f infrastructure/agent-sandbox/docker-compose.yml down",
     "agentic:dev-sandbox:reset": "docker compose -f infrastructure/agent-sandbox/docker-compose.yml down -v && docker compose -f infrastructure/agent-sandbox/docker-compose.yml up -d --build",
     "agentic:task:solve": "./infrastructure/agent-sandbox/solve-todo.sh",
+    "agentic:task:create": "./infrastructure/agent-sandbox/create-todo.sh",
     "vb-manager-next:start": "cd projects/nx-workspace && nx run vb-manager-next:pm2:start",
     "vb-manager-next:reload": "cd projects/nx-workspace && nx run vb-manager-next:pm2:reload",
     "vb-manager-next:delete": "cd projects/nx-workspace && nx run vb-manager-next:pm2:delete",


### PR DESCRIPTION
## Summary

Two additions to the unattended `agentic:task:*` family (ephemeral sandbox containers, deterministic commit/PR flow):

**1. `agentic:task:create <description>`** — researches a free-text description and adds a well-formed `TODO.md` entry (unique id, cited paths, numbered steps), then opens a PR containing only that `TODO.md` change. The opposite direction of `solve`: instead of resolving an existing item, it drafts one. Guardrail: the runner verifies only `TODO.md` changed.

**2. `agentic:task:solve --prompt "<task>"`** — a second mode for the existing solver, so you can hand the agent an ad-hoc task instead of only a `TODO.md` id:
```
pnpm agentic:task:solve --prompt "add a /health route to vb-express"
pnpm agentic:task:solve --model opus --prompt "create a simple react todo app"
pnpm agentic:task:solve abc123 def456      # id mode, unchanged — still fans out in parallel
```
The runner branches on `--id` vs `--prompt`: id mode keeps the `TODO.md` extract + post-solve cleanup; prompt mode skips both and solves the given text. The branch/commit/push/PR skeleton and the `--model` flag are shared/unchanged. `--prompt` runs a single container; ids still run in parallel. Mixing `--prompt` with ids errors out.

All three scripts (`solve-todo.sh`, `solve-todo-runner.sh`, `create-todo*.sh`) share the same pattern: mint a per-run token, run `claude -p` with git/gh disallowed, then have the *script* deterministically commit and open the PR from a `meta.json` the agent writes.

Cheatsheet updated for both.

## Caveats

- **Untested end-to-end** — verified with `bash -n` + arg-parsing smoke tests; the full docker/sandbox flow wasn't run (no local sandbox creds in-session).
- Free-text tasks that need network or deploy credentials (e.g. "deploy via wrangler pages") depend on the sandbox's firewall allowlist (`SANDBOX_ALLOWED_DOMAINS`) and whatever secrets are injected via `SANDBOX_VAULT_ENV_VARS` — a bare prompt won't magically have Cloudflare/deploy auth. The mechanism to *pass* such a task is what this adds; whether a given task can complete depends on the sandbox environment.
- The sandbox clones fresh `main`, so these operate on merged code, not your local working tree.

## Test plan

- [x] `bash -n` on all changed scripts
- [x] arg-parsing smoke test (ids vs `--prompt` vs `--model` route correctly; mixing errors)
- [x] `pnpm run cheatsheet` renders the new lines
- [ ] `pnpm agentic:task:create "some test description"` → PR with only a TODO.md entry
- [ ] `pnpm agentic:task:solve --prompt "add a trivial README note"` → PR with the change
- [ ] `pnpm agentic:task:solve <existing-id>` → id mode still works (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)