### PR TITLE
fix(github-actions): Point upptime's git push at the admin PAT, not the ambient bot token.

### DIFF
--- a/.github/workflows/cron-upptime-response-time.yml
+++ b/.github/workflows/cron-upptime-response-time.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Import Secrets from Vault
         uses: ./.github/actions/vault-secrets
         with:
@@ -28,6 +30,8 @@ jobs:
           gcp_service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           secrets: |
             kv/data/secrets GITHUB_TOKEN | GITHUB_TOKEN ;
+      - name: Point origin at the admin PAT for push
+        run: git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
       - name: Warm fly.io services
         continue-on-error: true
         run: |

--- a/.github/workflows/cron-upptime.yml
+++ b/.github/workflows/cron-upptime.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
       - name: Import Secrets from Vault
         uses: ./.github/actions/vault-secrets
         with:
@@ -28,6 +30,8 @@ jobs:
           gcp_service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           secrets: |
             kv/data/secrets GITHUB_TOKEN | GITHUB_TOKEN ;
+      - name: Point origin at the admin PAT for push
+        run: git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
       - name: Warm fly.io services
         continue-on-error: true
         run: |


### PR DESCRIPTION
## Summary

Root cause of [run 29758101258](https://github.com/iamharryliu/vigilant-broccoli/actions/runs/29758101258) still failing with `GH013` even after PR #140/#141's Vault-PAT wiring: `upptime/uptime-monitor`'s [`push()`](https://github.com/upptime/uptime-monitor/blob/master/src/helpers/git.ts) runs a bare `git push` with no embedded credentials —

```ts
export const push = () => {
  runGit(["push"], true);
};
```

`GH_PAT` is only read in [`index.ts`](https://github.com/upptime/uptime-monitor/blob/master/src/index.ts) (`getSecret("GH_PAT") || ...`) to authenticate the tool's **Octokit** calls (creating/closing status issues, the summary README write happens in-repo but the *push* itself never touches that token). The git-level push instead relies entirely on whatever credential `actions/checkout` persisted — by default the ephemeral `github-actions[bot]` installation token, which has no ruleset bypass. That's why the error changed from `GH006` (classic branch protection) to `GH013` (ruleset) but the actual blocked identity never changed.

- `persist-credentials: false` on `actions/checkout`, so it stops storing that bot-token credential helper entry.
- New step right after "Import Secrets from Vault": `git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"` — embeds the admin PAT (imported from Vault, per #140) directly in the `origin` URL, so upptime's bare `git push` now authenticates as `iamharryliu` and matches the ruleset's `RepositoryRole` bypass.
- `GH_PAT: ${{ env.GITHUB_TOKEN }}` on the `upptime/uptime-monitor` steps is unchanged — still needed for its Octokit calls.

## Test plan

- [x] `check yaml` pre-commit hook passes on both workflow files
- [ ] `gh workflow run cron-upptime-response-time.yml` succeeds, with a new `Upptime Bot` commit landing on `main`
- [ ] `gh workflow run cron-upptime.yml` succeeds
- [ ] `gh run view --log-failed` on the new runs shows no `GH006`/`GH013`

🤖 Generated with [Claude Code](https://claude.com/claude-code)