### PR TITLE
feat(vb-manager-next): Add Base64 encode/decode to text-tools

### DIFF
--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/pages/TextToolsPage.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/pages/TextToolsPage.tsx
@@ -13,6 +13,8 @@ export const TextToolsPage = () => {
       <CleanEnvConversionForm />
       <StubbedJSONValuesForm />
       <FormatBlockStringToSingleStringForm />
+      <TextToBase64Form />
+      <Base64ToTextForm />
       <CharacterCounter />
     </div>
   );
@@ -116,6 +118,38 @@ const FormatBlockStringToSingleStringForm = () => {
       initialText={''}
       sampleText={SAMPLE_BLOCK_STRING}
       conversionFn={EnvUtils.formatBlockStringToSingleLineString}
+    />
+  );
+};
+
+const SAMPLE_TEXT_FOR_BASE64 = `-----BEGIN PRIVATE KEY-----\nMIIBVAIBADANBgkqhki\n-----END PRIVATE KEY-----`;
+
+const TextToBase64Form = () => {
+  return (
+    <ConversionForm
+      copy={{
+        header: 'Text to Base64',
+        placeholder: SAMPLE_TEXT_FOR_BASE64,
+      }}
+      initialText={''}
+      sampleText={SAMPLE_TEXT_FOR_BASE64}
+      conversionFn={EnvUtils.encodeBase64}
+    />
+  );
+};
+
+const SAMPLE_BASE64 = EnvUtils.encodeBase64('hello world');
+
+const Base64ToTextForm = () => {
+  return (
+    <ConversionForm
+      copy={{
+        header: 'Base64 to Text',
+        placeholder: SAMPLE_BASE64,
+      }}
+      initialText={''}
+      sampleText={SAMPLE_BASE64}
+      conversionFn={EnvUtils.decodeBase64}
     />
   );
 };

--- a/projects/nx-workspace/libs/@vigilant-broccoli/common-js/src/lib/utils/env.utils.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/common-js/src/lib/utils/env.utils.ts
@@ -78,6 +78,23 @@ function formatBlockStringToSingleLineString(block: string): string {
   return block.split(/\r?\n/).join('\\n');
 }
 
+function encodeBase64(text: string): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  bytes.forEach(byte => (binary += String.fromCharCode(byte)));
+  return btoa(binary);
+}
+
+function decodeBase64(base64: string): string {
+  try {
+    const binary = atob(base64.trim());
+    const bytes = Uint8Array.from(binary, char => char.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  } catch {
+    return '';
+  }
+}
+
 export const EnvUtils = {
   getPrettierJSON,
   getEnvironmentVariablesFromJSON,
@@ -85,4 +102,6 @@ export const EnvUtils = {
   getStubbedEnvironmentVariableKeys,
   getStubbedJSONValues,
   formatBlockStringToSingleLineString,
+  encodeBase64,
+  decodeBase64,
 };

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/components/ConversionForm.tsx
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/components/ConversionForm.tsx
@@ -18,7 +18,7 @@ export const ConversionForm = ({
 
   const isSupportedFile = (file: File) => {
     const supportedTypes = ['text/', 'application/json', 'application/csv'];
-    const supportedExtensions = ['.txt', '.json', '.csv'];
+    const supportedExtensions = ['.txt', '.json', '.csv', '.pem', '.env'];
 
     const mimeOk = supportedTypes.some(type => file.type.startsWith(type));
     const extOk = supportedExtensions.some(ext =>
@@ -45,7 +45,9 @@ export const ConversionForm = ({
       };
       reader.readAsText(file);
     } else {
-      alert('Unsupported file type. Please drop a .txt, .json, or .csv file.');
+      alert(
+        'Unsupported file type. Please drop a .txt, .json, .csv, .pem, or .env file.',
+      );
     }
   }, []);
 
@@ -71,7 +73,7 @@ export const ConversionForm = ({
             onChange={e => setText(e.target.value)}
             placeholder={copy.placeholder}
             size="3"
-            className='h-full'
+            className="h-full"
             resize="vertical"
           />
         </div>


### PR DESCRIPTION
## Summary
- Add **Text to Base64** and **Base64 to Text** tools to the vb-manager-next `text-tools` page, mirroring the page's existing bidirectional conversion pattern.
- Add `EnvUtils.encodeBase64` / `EnvUtils.decodeBase64` to `@vigilant-broccoli/common-js` using browser-standard `TextEncoder`/`btoa`/`atob` (no `Buffer`, since the conversion runs in the client component). Encoding is single-line with no wrapping, matching `base64 -i file | tr -d '\n'`; decode returns `''` on invalid input.
- Extend `ConversionForm` drag-drop to accept `.pem` and `.env` files (and update the alert copy) so a private key can be dropped straight onto the encoder.
- Together this replaces the `base64 -i ~/Downloads/*.pem | tr -d '\n' | pbcopy` CLI flow — the `CopyPastable` copy button is the `pbcopy` equivalent.

## Test plan
- [x] Typecheck passes on `common-js`.
- [x] `encodeBase64` output verified byte-for-byte identical to `base64 -i file | tr -d '\n'` for a PEM sample.
- [x] Round-trip `decodeBase64(encodeBase64(text)) === text` confirmed.
- [ ] In the UI: paste text / drop a `.pem` into **Text to Base64** → single-line base64 appears → copy button works.
- [ ] Paste a base64 string into **Base64 to Text** → original text appears; invalid input yields empty result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)