### PR TITLE
docs(todo): Track locking down vb-llm-service and scoping the fly gateway

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -303,6 +303,44 @@ Desired end state: the key is on a rotation path — at minimum listed as a manu
 3. If scripted, wire it into `pnpm secret-rotation:all` and the rotation table in `docs/infrastructure/secret-rotation-implementation.md`, matching the existing entries' columns.
 4. Cross-check `docs/infrastructure/secret-management.md`'s key inventory (Deploy secrets tier) actually lists `UPPTIME_GH_APP_PRIVATE_KEY` — it was added ad hoc during the GitHub App migration and may not be in the canonical inventory yet.
 
+### 455179. [security] vb-llm-service is unnecessarily public — lock it down to Fly's private network only
+
+**`projects/nx-workspace/deployment-configs/fly-configs/{staging,production}-llm-service.toml`** · consumer: `apps/api/vb-express/src/libs/llm-service.client.ts:11` (`LLM_SERVICE_URL`, set in `deployment-configs/fly-configs/{staging,production}-vb-express.toml:10`)
+
+llm-service is reachable at `https://{staging,production}-vb-llm-service.fly.dev`, but grep across the workspace shows the only caller anywhere in the repo is vb-express. No Vercel app, browser client, or third party hits it. 4eb262 already flags the public-edge hop for performance (extra TLS round trip, chained cold starts); this entry is the security half — don't just switch the URL scheme, remove the public IPs entirely so the fly.dev hostname stops resolving to anything reachable at all.
+
+Desired end state: llm-service has no public IPv4/IPv6 allocated; vb-express reaches it only over Fly's private 6PN network; CI's e2e/security suites (currently run from `ubuntu-latest` runners against the public URL) tunnel in instead of failing.
+
+**Steps:**
+
+1. For both `staging-vb-llm-service` and `production-vb-llm-service`, release the public IPs: `flyctl ips list -a <app>` then `flyctl ips release <ip>` for each v4/v6 address.
+2. Allocate a private flycast address so llm-service keeps fly-proxy's health-aware routing/auto-start behavior while staying internal-only: `flyctl ips allocate-v6 --private -a <app>` for both environments.
+3. Update `LLM_SERVICE_URL` in `staging-vb-express.toml` and `production-vb-express.toml` from `https://<env>-vb-llm-service.fly.dev` to `http://<env>-vb-llm-service.flycast` — plain http, no TLS on the private network. This also folds in 4eb262's fix for this leg.
+4. `.github/workflows/test-e2e-llm.yml:47` and `test-security-llm.yml:35` set `LLM_SERVICE_URL` to the public fly.dev URL and run on `ubuntu-latest` — they'll stop being able to reach the service. Add a `flyctl proxy` step (reusing `FLY_API_TOKEN` from Vault the same way `deploy.yml:171` does) to tunnel a local port to the app's private address before `scripts/shell/test-llm-e2e.sh` / `test-llm-security.sh` run, and point `LLM_SERVICE_URL` at the local proxy port.
+5. Update `docs/infrastructure/network-management.md`'s fly.dev URL table — llm-service moves from the public list to private-only, reachable via flycast from other Fly apps.
+6. Deploy both environments and verify: `curl https://staging-vb-llm-service.fly.dev` fails to connect (no public IP); an LLM/chat request through vb-express still succeeds.
+
+### 0e704f. [security] Plan: route vb-email-service and vb-storage-service through vb-express instead of exposing them directly
+
+Follow-up to 455179. Unlike llm-service, these two services can't just have their public IPs released — they're called directly by apps that aren't on Fly's private network:
+
+- **vb-email-service**: called by vb-express (`apps/api/vb-express/src/routes/messaging.ts:99`) and by email-subscription-service (`apps/api/email-subscription-service/src/main.ts:30,90` — itself a Fly app, so this leg _can_ move to flycast independent of the rest), plus three Vercel-hosted callers that hit the public fly.dev URL directly: `apps/hearth/src/app/api/homes/[id]/members/route.ts:9-12`, `apps/ui/small-business-next/src/app/api/notify/route.ts:8-9`, `apps/ui/vb-manager-next/src/app/api/send-email-message/route.ts:22`.
+- **vb-storage-service** (bucket-service): called only by `apps/ui/vb-manager-next/src/app/api/bucket/route.ts:9-27` (upload/download/list), also from Vercel.
+- **email-subscription-service** itself has public `/api/subscribe`, `/api/unsubscribe`, `/api/notify` routes (`apps/api/email-subscription-service/src/main.ts:167-278`) with no in-repo caller found — needs a decision on whether it's intentionally a public-facing API (future newsletter signup) or can be locked down too.
+
+Vercel serverless functions can't join Fly's 6PN network, so fully closing this off means adding proxy/passthrough routes on vb-express and repointing those Vercel apps at vb-express's public URL instead of the backend services' fly.dev URLs — real app-code work across 4+ apps, not just a fly.toml change. This entry is scoping/planning only; no implementation.
+
+**Steps:**
+
+1. Decide per service whether to gateway it through vb-express or accept it stays public:
+   - vb-email-service: design a `POST /api/gateway/send-email`-style route on vb-express that forwards to email-service internally (flycast), matching the existing `API_KEY_HEADER`/`SHARED_APP_TOKEN` auth pattern (`llm-service.client.ts:15`, `messaging.ts`). If adopted, repoint hearth/small-business-next/vb-manager-next's `EMAIL_SERVICE_URL` at vb-express's public URL and update `scripts/deploy-vercel.ts:175-176`, which currently injects the raw email-service URL into Vercel env.
+   - vb-storage-service: design equivalent passthrough routes for `apps/ui/vb-manager-next/src/app/api/bucket/route.ts`'s upload/download/list operations, noting these may carry larger/streamed payloads than the JSON email gateway.
+   - email-subscription-service: resolve whether its public routes are intentional (legitimate exception to "vb-express only") or unused and safe to lock down once a real caller exists.
+2. For whichever services move behind the gateway, add the vb-express routes, then repeat 455179's lockdown steps (release public IPs, allocate flycast, update fly-configs) for each.
+3. Update the calling apps' env vars/URLs to point at vb-express instead of the backend services directly.
+4. Update `docs/api/deployment/fly-service-pattern.md` and `docs/infrastructure/network-management.md` once the target architecture is decided; cross-reference 4eb262 (private-networking performance) and 240ff8 (open email relay hardening), which overlap with whatever ends up staying public.
+5. Whatever stays public after step 1 should get hardening (240ff8 already covers vb-email-service's caller-controlled to/from/html; consider similar allowlisting for bucket-service) rather than being left exposed with no mitigation.
+
 ## P3
 
 ### 9f4e45. [security] Non-constant-time API-key comparison


### PR DESCRIPTION
## Summary
- Add TODO 455179: release vb-llm-service's public IPs and route vb-express to it over Fly's private `.flycast` network (it's the only in-repo caller), including updating the two CI workflows that currently hit its public URL from GitHub-hosted runners.
- Add TODO 0e704f: scope (not implement) the larger follow-up of gatewaying vb-email-service and vb-storage-service through vb-express, since — unlike llm-service — they're called directly by three Vercel-hosted apps that can't join Fly's private network.

## Test plan
- [ ] N/A — TODO.md only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)