### PR TITLE
feat(agent-sandbox): Add agentic:pr:fix and run pre-commit before agent commits

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -94,6 +94,7 @@ Useful infra-level CLI commands, runnable via `pnpm run <script>`.
   agentic:task:solve <id...>  Headlessly solve TODO.md item(s) in parallel ephemeral sandbox containers; each opens a PR (sonnet; --model <m> to override)
                                (or --prompt "<task>" to solve a free-text task instead of TODO ids, e.g. "add a /health route to vb-express")
   agentic:task:create <desc>  Headlessly research and add a TODO.md entry for <desc> in an ephemeral sandbox container, then open a PR (sonnet; --model <m> to override)
+  agentic:pr:fix <pr>         Headlessly fix a PR's failing CI in an ephemeral sandbox container (checks out the branch, feeds the failing logs to the agent, runs pre-commit, pushes the fix); accepts a PR number or URL (sonnet; --model <m> to override)
 
 🏠 HOMELAB
   homelab:up                  Start homelab services and Tailscale

--- a/infrastructure/agent-sandbox/Dockerfile
+++ b/infrastructure/agent-sandbox/Dockerfile
@@ -4,7 +4,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git gnupg openssh-client iproute2 procps less \
     iptables ipset dnsutils \
     tmux vim neovim fzf ripgrep jq lsof zip unzip \
-    && rm -rf /var/lib/apt/lists/*
+    python3 python3-pip python3-venv \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --no-cache-dir --break-system-packages pre-commit
 
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \

--- a/infrastructure/agent-sandbox/create-todo-runner.sh
+++ b/infrastructure/agent-sandbox/create-todo-runner.sh
@@ -75,6 +75,8 @@ echo "$TRAILER" | grep -Eqi '^co-authored-by: .+ <.+>$' || TRAILER="$FALLBACK_TR
 [ -n "$PR_SUMMARY" ] || PR_SUMMARY="- Add TODO entry${TODO_ID:+ ${TODO_ID}} for: ${DESCRIPTION}"
 [ -n "$PR_TEST_PLAN" ] || PR_TEST_PLAN="- [ ] Entry reviewed for accuracy and actionable steps"
 
+bash "$REPO_DIR/infrastructure/agent-sandbox/run-pre-commit.sh"
+
 git add TODO.md
 git commit -m "$COMMIT_SUBJECT" -m "$TRAILER"
 git push -u origin "$BRANCH"

--- a/infrastructure/agent-sandbox/fix-pr-runner.sh
+++ b/infrastructure/agent-sandbox/fix-pr-runner.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -euo pipefail
+
+PR=${1:?Usage: fix-pr-runner.sh <PR_NUMBER_OR_URL>}
+MODEL=${SOLVE_MODEL:-sonnet}
+REPO_DIR="$HOME/vigilant-broccoli"
+META_FILE=/tmp/fix-meta.json
+CI_LOG=/tmp/pr-ci-failures.log
+CI_LOG_BUDGET=20000
+PR_FOOTER='🤖 Generated with [Claude Code](https://claude.com/claude-code)'
+FALLBACK_TRAILER='Co-authored-by: Claude <noreply@anthropic.com>'
+
+cd "$REPO_DIR"
+
+git fetch origin --quiet
+gh pr checkout "$PR"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BASE_SHA=$(git rev-parse HEAD)
+rm -f "$META_FILE"
+
+: > "$CI_LOG"
+gh pr checks "$PR" >> "$CI_LOG" 2>&1 || true
+for run_id in $(gh run list --branch "$BRANCH" --limit 15 \
+  --json databaseId,conclusion -q '.[] | select(.conclusion == "failure") | .databaseId'); do
+  echo "===== failing run $run_id =====" >> "$CI_LOG"
+  gh run view "$run_id" --log-failed >> "$CI_LOG" 2>&1 || true
+done
+FAILURES=$(tail -c "$CI_LOG_BUDGET" "$CI_LOG")
+
+PROMPT=$(cat <<EOF
+You are running non-interactively in a checkout of pull request #${PR} (branch ${BRANCH}) of vigilant-broccoli. Its CI is failing. Fix the code on this branch so the checks pass.
+
+Failing CI output (checks summary followed by failed-step logs):
+
+${FAILURES}
+
+Rules:
+- Diagnose from the logs above, then make the minimal changes needed to make CI pass, following the repo conventions in CLAUDE.md.
+- Formatting failures from the pre-commit job (trailing-whitespace, end-of-file-fixer, black) are auto-fixed for you by the calling script — do not hand-fix whitespace; spend your effort on real lint, test, build, or logic failures.
+- Do not run any git or gh commands — committing, pushing, and commenting are handled by the calling script.
+- When finished, write $META_FILE containing only a JSON object with these string fields:
+  - commit_type: one of feat, fix, ci, chore, docs, refactor, enhancement, security, infrastructure
+  - commit_scope: the affected app/service/lib name, or "" when the change is not scoped to one
+  - commit_message: capitalized, concise, focused on why not what, ending with a period
+  - co_authored_by: the Co-Authored-By trailer line specified by your environment for the model authoring the commit
+  - pr_comment: one short sentence describing what you changed to fix CI, for a PR comment
+EOF
+)
+
+claude -p "$PROMPT" --dangerously-skip-permissions --model "$MODEL" \
+  --disallowedTools "Bash(git commit:*)" "Bash(git push:*)" "Bash(git checkout:*)" "Bash(git switch:*)" "Bash(gh:*)"
+
+git checkout "$BRANCH"
+[ "$(git rev-parse HEAD)" = "$BASE_SHA" ] || git reset --soft "$BASE_SHA"
+
+bash "$REPO_DIR/infrastructure/agent-sandbox/run-pre-commit.sh"
+
+if [ -z "$(git status --porcelain)" ]; then
+  echo "ERROR: no changes produced — PR #${PR} CI failure was not fixed." >&2
+  exit 1
+fi
+
+read_meta() { jq -r "$1 // empty" "$META_FILE" 2>/dev/null || true; }
+
+COMMIT_TYPE=$(read_meta .commit_type)
+COMMIT_SCOPE=$(read_meta .commit_scope)
+COMMIT_MESSAGE=$(read_meta .commit_message)
+TRAILER=$(read_meta .co_authored_by)
+PR_COMMENT=$(read_meta .pr_comment)
+
+case "$COMMIT_TYPE" in
+  feat | fix | ci | chore | docs | refactor | enhancement | security | infrastructure) ;;
+  *) COMMIT_TYPE="" ;;
+esac
+
+if [ -n "$COMMIT_TYPE" ] && [ -n "$COMMIT_MESSAGE" ]; then
+  if [ -n "$COMMIT_SCOPE" ]; then
+    COMMIT_SUBJECT="${COMMIT_TYPE}(${COMMIT_SCOPE}): ${COMMIT_MESSAGE}"
+  else
+    COMMIT_SUBJECT="${COMMIT_TYPE}: ${COMMIT_MESSAGE}"
+  fi
+else
+  COMMIT_SUBJECT="ci: Fix failing checks on PR #${PR}."
+fi
+
+echo "$TRAILER" | grep -Eqi '^co-authored-by: .+ <.+>$' || TRAILER="$FALLBACK_TRAILER"
+
+git add -A
+git commit -m "$COMMIT_SUBJECT" -m "$TRAILER"
+git push
+
+[ -n "$PR_COMMENT" ] && gh pr comment "$PR" --body "$PR_COMMENT
+
+$PR_FOOTER" || true

--- a/infrastructure/agent-sandbox/fix-pr.sh
+++ b/infrastructure/agent-sandbox/fix-pr.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+IMAGE=vb-agent-sandbox
+
+MODEL=sonnet
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --model)
+      MODEL=$2
+      shift 2
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+PR="${ARGS[0]:-}"
+if [ -z "$PR" ] || [ ${#ARGS[@]} -gt 1 ]; then
+  echo "Usage: pnpm agentic:pr:fix [--model <model>] <PR_NUMBER_OR_URL>" >&2
+  exit 1
+fi
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  docker compose -f "$SCRIPT_DIR/docker-compose.yml" build
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  "$SCRIPT_DIR/load-env-from-vault.sh"
+fi
+
+GH_TOKEN_VALUE=$(grep '^GH_TOKEN=' "$ENV_FILE" | cut -d= -f2-)
+APP_ID=$(grep '^AGENT_GH_APP_ID=' "$ENV_FILE" | cut -d= -f2-)
+PEM_FILE="$SCRIPT_DIR/.github-app-key.pem"
+if [ -n "$APP_ID" ] && [ -f "$PEM_FILE" ]; then
+  echo "Minting fresh GitHub App installation token..."
+  GH_TOKEN_VALUE=$("$SCRIPT_DIR/mint-github-app-token.sh" "$APP_ID" "$PEM_FILE")
+fi
+
+if [ -z "$GH_TOKEN_VALUE" ]; then
+  echo "ERROR: no GitHub token available — this cannot check out, push, or comment on the PR." >&2
+  echo "Add GitHub App credentials or a fine-grained PAT to Vault (see docs/infrastructure/secret-management.md), then run: pnpm agentic:dev-sandbox:up" >&2
+  exit 1
+fi
+
+echo "Fixing CI on PR (model: $MODEL): $PR"
+docker run --rm --init --name "vb-fix-pr-$(date +%s)" \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  --env-file "$ENV_FILE" \
+  -e GH_TOKEN="$GH_TOKEN_VALUE" \
+  -e SOLVE_MODEL="$MODEL" \
+  "$IMAGE" \
+  bash -c 'exec bash "$HOME/vigilant-broccoli/infrastructure/agent-sandbox/fix-pr-runner.sh" "$1"' _ "$PR"

--- a/infrastructure/agent-sandbox/init-firewall.sh
+++ b/infrastructure/agent-sandbox/init-firewall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-ALLOWED_DOMAINS="registry.npmjs.org api.anthropic.com claude.ai console.anthropic.com statsig.anthropic.com statsig.com sentry.io $*"
+ALLOWED_DOMAINS="registry.npmjs.org pypi.org files.pythonhosted.org api.anthropic.com claude.ai console.anthropic.com statsig.anthropic.com statsig.com sentry.io $*"
 DEV_PORTS=3000,4200,8080
 IPSET_NAME=allowed-hosts
 

--- a/infrastructure/agent-sandbox/run-pre-commit.sh
+++ b/infrastructure/agent-sandbox/run-pre-commit.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+# Auto-fix the working tree with the same hooks ci-pr-check runs (SKIP mirrors the workflow),
+# so agent commits never fail the pre-commit job. First pass auto-fixes; second pass must be
+# clean or the caller aborts. Run from the repo root (where .pre-commit-config.yaml lives).
+export SKIP=grind-75-tests,lint-staged
+
+pre-commit run --all-files || pre-commit run --all-files

--- a/infrastructure/agent-sandbox/solve-todo-runner.sh
+++ b/infrastructure/agent-sandbox/solve-todo-runner.sh
@@ -138,6 +138,8 @@ echo "$TRAILER" | grep -Eqi '^co-authored-by: .+ <.+>$' || TRAILER="$FALLBACK_TR
 [ -n "$PR_SUMMARY" ] || PR_SUMMARY="$FALLBACK_SUMMARY"
 [ -n "$PR_TEST_PLAN" ] || PR_TEST_PLAN="- [ ] CI passes"
 
+bash "$REPO_DIR/infrastructure/agent-sandbox/run-pre-commit.sh"
+
 git add -A
 git commit -m "$COMMIT_SUBJECT" -m "$TRAILER"
 git push -u origin "$BRANCH"

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "agentic:dev-sandbox:reset": "docker compose -f infrastructure/agent-sandbox/docker-compose.yml down -v && docker compose -f infrastructure/agent-sandbox/docker-compose.yml up -d --build",
     "agentic:task:solve": "./infrastructure/agent-sandbox/solve-todo.sh",
     "agentic:task:create": "./infrastructure/agent-sandbox/create-todo.sh",
+    "agentic:pr:fix": "./infrastructure/agent-sandbox/fix-pr.sh",
     "vb-manager-next:start": "cd projects/nx-workspace && nx run vb-manager-next:pm2:start",
     "vb-manager-next:reload": "cd projects/nx-workspace && nx run vb-manager-next:pm2:reload",
     "vb-manager-next:delete": "cd projects/nx-workspace && nx run vb-manager-next:pm2:delete",


### PR DESCRIPTION
## Summary

- **Root cause**: agent-authored PRs (e.g. `agent/todo-455179` in [run 29810326935](https://github.com/iamharryliu/vigilant-broccoli/actions/runs/29810326935)) were failing the `ci-pr-check` **pre-commit** job — the sandbox committed without running the hooks, so formatting drift (a trailing blank line caught by `end-of-file-fixer`) only surfaced in CI.
- **New `run-pre-commit.sh`** helper runs `pre-commit run --all-files` with the same `SKIP=grind-75-tests,lint-staged` as CI: first pass auto-fixes, second pass must be clean or the run aborts loudly instead of opening a red PR.
- Wired that helper into `solve-todo-runner.sh` and `create-todo-runner.sh` right before their commit, so `agentic:task:solve` / `:create` stop producing pre-commit failures.
- **New `pnpm agentic:pr:fix <PR>`** command (host wrapper `fix-pr.sh` + in-container `fix-pr-runner.sh`): checks out a failing PR by number or URL in an ephemeral sandbox, feeds the failing check summary + `--log-failed` output to the agent, runs pre-commit, then commits + pushes to the same branch and drops a PR comment.
- `Dockerfile` installs `python3` + `pre-commit`; `init-firewall.sh` allowlists `pypi.org` / `files.pythonhosted.org` so pre-commit can build its hook envs inside the default-deny sandbox.
- Documented the new command in `docs/cheatsheet.md`.

## Test plan

- [x] `bash -n` passes on all new/changed scripts; `package.json` remains valid JSON.
- [x] Verified the `run-pre-commit.sh` double-run in an isolated repo against the exact PR #149 failure: pass 1 auto-fixed the trailing blank line, pass 2 passed clean, exit 0.
- [ ] `pnpm agentic:dev-sandbox:reset` to rebuild the image with pre-commit/python.
- [ ] `pnpm agentic:pr:fix <a-failing-PR>` checks out, fixes, and pushes so CI re-runs green.
- [ ] A fresh `agentic:task:solve` / `:create` PR passes the `pre-commit` CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)