### PR TITLE
feat(agent-sandbox): Add agentic:pr:update to apply free-text changes to a PR

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -95,6 +95,7 @@ Useful infra-level CLI commands, runnable via `pnpm run <script>`.
                                (or --prompt "<task>" to solve a free-text task instead of TODO ids, e.g. "add a /health route to vb-express")
   agentic:task:create <desc>  Headlessly research and add a TODO.md entry for <desc> in an ephemeral sandbox container, then open a PR (sonnet; --model <m> to override)
   agentic:pr:fix <pr>         Headlessly fix a PR's failing CI in an ephemeral sandbox container (checks out the branch, feeds the failing logs to the agent, runs pre-commit, pushes the fix); accepts a PR number or URL (sonnet; --model <m> to override)
+  agentic:pr:update <pr> <instruction>  Headlessly apply a free-text change to an existing PR's branch in an ephemeral sandbox container (checks out the branch, runs the agent on your instruction, runs pre-commit, pushes the update); accepts a PR number or URL (sonnet; --model <m> to override)
 
 🏠 HOMELAB
   homelab:up                  Start homelab services and Tailscale

--- a/infrastructure/agent-sandbox/update-pr-runner.sh
+++ b/infrastructure/agent-sandbox/update-pr-runner.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -euo pipefail
+
+PR=${1:?Usage: update-pr-runner.sh <PR_NUMBER_OR_URL> <instruction>}
+INSTRUCTION=${2:?Usage: update-pr-runner.sh <PR_NUMBER_OR_URL> <instruction>}
+MODEL=${SOLVE_MODEL:-sonnet}
+REPO_DIR="$HOME/vigilant-broccoli"
+META_FILE=/tmp/update-meta.json
+PR_FOOTER='🤖 Generated with [Claude Code](https://claude.com/claude-code)'
+FALLBACK_TRAILER='Co-authored-by: Claude <noreply@anthropic.com>'
+PRE_COMMIT_HELPER=/tmp/run-pre-commit.sh
+
+cd "$REPO_DIR"
+
+# Stash the helper outside the working tree before checkout — the PR branch may predate it,
+# and gh pr checkout would otherwise leave us on a branch where the helper path doesn't exist.
+cp "$REPO_DIR/infrastructure/agent-sandbox/run-pre-commit.sh" "$PRE_COMMIT_HELPER"
+
+git fetch origin --quiet
+gh pr checkout "$PR"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+BASE_SHA=$(git rev-parse HEAD)
+rm -f "$META_FILE"
+
+PR_TITLE=$(gh pr view "$PR" --json title -q .title 2>/dev/null || true)
+
+PROMPT=$(cat <<EOF
+You are running non-interactively in a checkout of pull request #${PR}${PR_TITLE:+ ("${PR_TITLE}")} (branch ${BRANCH}) of vigilant-broccoli. Apply the following change to this PR's branch, building on the work already there:
+
+${INSTRUCTION}
+
+Rules:
+- Make only the changes needed to satisfy the request, following the repo conventions in CLAUDE.md. Read the code already on this branch first and extend it rather than starting over.
+- Do not run any git or gh commands — committing, pushing, and commenting are handled by the calling script.
+- When finished, write $META_FILE containing only a JSON object with these string fields:
+  - commit_type: one of feat, fix, ci, chore, docs, refactor, enhancement, security, infrastructure
+  - commit_scope: the affected app/service/lib name, or "" when the change is not scoped to one
+  - commit_message: capitalized, concise, focused on why not what, ending with a period
+  - co_authored_by: the Co-Authored-By trailer line specified by your environment for the model authoring the commit
+  - pr_comment: one short sentence describing what you changed, for a PR comment
+EOF
+)
+
+claude -p "$PROMPT" --dangerously-skip-permissions --model "$MODEL" \
+  --disallowedTools "Bash(git commit:*)" "Bash(git push:*)" "Bash(git checkout:*)" "Bash(git switch:*)" "Bash(gh:*)"
+
+git checkout "$BRANCH"
+[ "$(git rev-parse HEAD)" = "$BASE_SHA" ] || git reset --soft "$BASE_SHA"
+
+bash "$PRE_COMMIT_HELPER"
+
+if [ -z "$(git status --porcelain)" ]; then
+  echo "ERROR: no changes produced — PR #${PR} was not updated." >&2
+  exit 1
+fi
+
+read_meta() { jq -r "$1 // empty" "$META_FILE" 2>/dev/null || true; }
+
+COMMIT_TYPE=$(read_meta .commit_type)
+COMMIT_SCOPE=$(read_meta .commit_scope)
+COMMIT_MESSAGE=$(read_meta .commit_message)
+TRAILER=$(read_meta .co_authored_by)
+PR_COMMENT=$(read_meta .pr_comment)
+
+case "$COMMIT_TYPE" in
+  feat | fix | ci | chore | docs | refactor | enhancement | security | infrastructure) ;;
+  *) COMMIT_TYPE="" ;;
+esac
+
+if [ -n "$COMMIT_TYPE" ] && [ -n "$COMMIT_MESSAGE" ]; then
+  if [ -n "$COMMIT_SCOPE" ]; then
+    COMMIT_SUBJECT="${COMMIT_TYPE}(${COMMIT_SCOPE}): ${COMMIT_MESSAGE}"
+  else
+    COMMIT_SUBJECT="${COMMIT_TYPE}: ${COMMIT_MESSAGE}"
+  fi
+else
+  COMMIT_SUBJECT="chore: Apply requested update to PR #${PR}."
+fi
+
+echo "$TRAILER" | grep -Eqi '^co-authored-by: .+ <.+>$' || TRAILER="$FALLBACK_TRAILER"
+
+git add -A
+git commit -m "$COMMIT_SUBJECT" -m "$TRAILER"
+git push
+
+[ -n "$PR_COMMENT" ] && gh pr comment "$PR" --body "$PR_COMMENT
+
+$PR_FOOTER" || true

--- a/infrastructure/agent-sandbox/update-pr.sh
+++ b/infrastructure/agent-sandbox/update-pr.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+IMAGE=vb-agent-sandbox
+
+MODEL=sonnet
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --model)
+      MODEL=$2
+      shift 2
+      ;;
+    --prompt)
+      ARGS+=("$2")
+      shift 2
+      ;;
+    *)
+      ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+PR="${ARGS[0]:-}"
+INSTRUCTION="${ARGS[*]:1}"
+if [ -z "$PR" ] || [ -z "$INSTRUCTION" ]; then
+  echo "Usage: pnpm agentic:pr:update [--model <model>] <PR_NUMBER_OR_URL> <instruction>" >&2
+  echo "  e.g. pnpm agentic:pr:update 149 \"add input validation to the new route\"" >&2
+  exit 1
+fi
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  docker compose -f "$SCRIPT_DIR/docker-compose.yml" build
+fi
+
+if [ ! -f "$ENV_FILE" ]; then
+  "$SCRIPT_DIR/load-env-from-vault.sh"
+fi
+
+GH_TOKEN_VALUE=$(grep '^GH_TOKEN=' "$ENV_FILE" | cut -d= -f2-)
+APP_ID=$(grep '^AGENT_GH_APP_ID=' "$ENV_FILE" | cut -d= -f2-)
+PEM_FILE="$SCRIPT_DIR/.github-app-key.pem"
+if [ -n "$APP_ID" ] && [ -f "$PEM_FILE" ]; then
+  echo "Minting fresh GitHub App installation token..."
+  GH_TOKEN_VALUE=$("$SCRIPT_DIR/mint-github-app-token.sh" "$APP_ID" "$PEM_FILE")
+fi
+
+if [ -z "$GH_TOKEN_VALUE" ]; then
+  echo "ERROR: no GitHub token available — this cannot check out, push, or comment on the PR." >&2
+  echo "Add GitHub App credentials or a fine-grained PAT to Vault (see docs/infrastructure/secret-management.md), then run: pnpm agentic:dev-sandbox:up" >&2
+  exit 1
+fi
+
+echo "Updating PR (model: $MODEL): #$PR — $INSTRUCTION"
+docker run --rm --init --name "vb-update-pr-$(date +%s)" \
+  --cap-add NET_ADMIN --cap-add NET_RAW \
+  --env-file "$ENV_FILE" \
+  -e GH_TOKEN="$GH_TOKEN_VALUE" \
+  -e SOLVE_MODEL="$MODEL" \
+  "$IMAGE" \
+  bash -c 'exec bash "$HOME/vigilant-broccoli/infrastructure/agent-sandbox/update-pr-runner.sh" "$1" "$2"' _ "$PR" "$INSTRUCTION"

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "agentic:task:solve": "./infrastructure/agent-sandbox/solve-todo.sh",
     "agentic:task:create": "./infrastructure/agent-sandbox/create-todo.sh",
     "agentic:pr:fix": "./infrastructure/agent-sandbox/fix-pr.sh",
+    "agentic:pr:update": "./infrastructure/agent-sandbox/update-pr.sh",
     "vb-manager-next:start": "cd projects/nx-workspace && nx run vb-manager-next:pm2:start",
     "vb-manager-next:reload": "cd projects/nx-workspace && nx run vb-manager-next:pm2:reload",
     "vb-manager-next:delete": "cd projects/nx-workspace && nx run vb-manager-next:pm2:delete",


### PR DESCRIPTION
## Summary

- Adds **`pnpm agentic:pr:update <PR> <instruction>`** — the counterpart to `agentic:pr:fix`, for iterating on an existing PR with a specific instruction rather than only remediating failing CI.
- Host wrapper `update-pr.sh` mints the GitHub App token (same pattern as `fix-pr.sh`/`create-todo.sh`) and runs an ephemeral sandbox container; `update-pr-runner.sh` checks out the PR branch, runs the agent on the instruction (git/gh mutations disallowed — the script owns commit/push), runs pre-commit, then commits and pushes to the same branch and drops a PR comment.
- Accepts a PR **number or URL**; the instruction is the remaining args (`--prompt "…"` also accepted). `--model <m>` overrides the default (sonnet).
- Reuses the shared `run-pre-commit.sh` helper via the same `/tmp` copy trick as `fix-pr` so it works even on PR branches that predate the helper.
- Documented in `docs/cheatsheet.md`.

Example:
```
pnpm agentic:pr:update 149 "add input validation to the new route"
```

## Test plan

- [x] `bash -n` passes on both new scripts; `package.json` remains valid JSON.
- [x] Verified wrapper arg-parsing under macOS bash 3.2 with `set -euo pipefail`: no-args and PR-only error out; PR+words, PR+quoted, `--prompt`, `--model`, and URL forms all parse correctly.
- [ ] `pnpm agentic:dev-sandbox:reset` (only needed if the image predates the pre-commit/python layer).
- [ ] `pnpm agentic:pr:update <open-PR> "<instruction>"` applies the change, runs pre-commit, and pushes a commit that turns the PR green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)