### PR TITLE
fix(llm-service): reach private llm-service over flycast:80 so e2e/security CI passes

### DIFF
--- a/.github/workflows/test-e2e-llm.yml
+++ b/.github/workflows/test-e2e-llm.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Tunnel to llm-service private network
         run: |
-          flyctl proxy 3000:3000 -a ${{ matrix.environment }}-vb-llm-service &
+          flyctl proxy 3000:80 ${{ matrix.environment }}-vb-llm-service.flycast -a ${{ matrix.environment }}-vb-llm-service &
           for i in $(seq 1 30); do
             curl -sf "${LLM_SERVICE_URL}/" >/dev/null 2>&1 && break
             sleep 1

--- a/.github/workflows/test-security-llm.yml
+++ b/.github/workflows/test-security-llm.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Tunnel to llm-service private network
         run: |
-          flyctl proxy 3000:3000 -a ${{ matrix.environment }}-vb-llm-service &
+          flyctl proxy 3000:80 ${{ matrix.environment }}-vb-llm-service.flycast -a ${{ matrix.environment }}-vb-llm-service &
           for i in $(seq 1 30); do
             curl -sf "${LLM_SERVICE_URL}/" >/dev/null 2>&1 && break
             sleep 1

--- a/docs/infrastructure/network-management.md
+++ b/docs/infrastructure/network-management.md
@@ -50,11 +50,11 @@ github.io                                 GitHub Pages
 
 ## Private-only Fly.io services
 
-Reachable only over Fly's private 6PN network via a flycast address — no public IPv4/IPv6 allocated, so the `fly.dev` hostname resolves to nothing reachable.
+Reachable only over Fly's private 6PN network via a flycast address — no public IPv4/IPv6 allocated, so the `fly.dev` hostname resolves to nothing reachable. Each app has a private ingress IPv6 (`fly ips allocate-v6 --private`) and `[http_service].force_https = false`, so the flycast edge serves the internal port over plain HTTP on port 80 (a `.internal` direct-machine dial would hit the app's IPv4-only `0.0.0.0` bind and reset; flycast routes through fly-proxy, which also auto-starts stopped machines).
 
 ```
-staging-vb-llm-service.flycast            LLM Service (staging) — called by staging-vb-express over 6PN
-production-vb-llm-service.flycast         LLM Service (production) — called by production-vb-express over 6PN
+staging-vb-llm-service.flycast            LLM Service (staging) — called by staging-vb-express via http://…flycast over 6PN
+production-vb-llm-service.flycast         LLM Service (production) — called by production-vb-express via http://…flycast over 6PN
 ```
 
-CI e2e/security suites reach these from `ubuntu-latest` runners by opening a `flyctl proxy` WireGuard tunnel to the app's private address (see `test-e2e-llm.yml`, `test-security-llm.yml`).
+CI e2e/security suites reach these from `ubuntu-latest` runners by opening a `flyctl proxy 3000:80 <app>.flycast -a <app>` WireGuard tunnel, then hitting `http://127.0.0.1:3000` (see `test-e2e-llm.yml`, `test-security-llm.yml`).

--- a/projects/nx-workspace/deployment-configs/fly-configs/production-llm-service.toml
+++ b/projects/nx-workspace/deployment-configs/fly-configs/production-llm-service.toml
@@ -9,7 +9,7 @@ primary_region = 'yyz'
 
 [http_service]
   internal_port = 3000
-  force_https = true
+  force_https = false
   auto_stop_machines = 'stop'
   auto_start_machines = true
   min_machines_running = 0

--- a/projects/nx-workspace/deployment-configs/fly-configs/staging-llm-service.toml
+++ b/projects/nx-workspace/deployment-configs/fly-configs/staging-llm-service.toml
@@ -9,7 +9,7 @@ primary_region = 'yyz'
 
 [http_service]
   internal_port = 3000
-  force_https = true
+  force_https = false
   auto_stop_machines = 'stop'
   auto_start_machines = true
   min_machines_running = 0


### PR DESCRIPTION
## Why CI broke

`#149` switched the llm e2e/security suites to reach llm-service through
`flyctl proxy 3000:3000 -a <app>`, which dials `<app>.internal` — a **direct 6PN
IPv6** address. The app binds `HOST=0.0.0.0` (IPv4 only), so nothing is listening on
the machine's IPv6 6PN interface → the tunnel resets (`curl (56) Connection reset by
peer`). Reproduced against the real VM **even with the machine running** — so it was
never going to work, not just an auto-stop race. `.internal` also can't auto-start a
stopped machine.

`#149` also only ever changed CI + docs + the express URL: the llm-service apps still
had **public IPs**, still had `force_https = true`, and had **no flycast IP** — so the
"private lockdown" was never actually applied.

## Fix

Route through **flycast** instead of `.internal`. Flycast goes via fly-proxy (same as
the public edge): it maps the `http_service` port to `internal_port` **and auto-starts
stopped machines**. Because flycast exposes the service on ports 80/443 (not 3000) and
`force_https` would 301-redirect port 80 to a TLS port with no internal cert, this
change sets `force_https = false` so flycast serves the internal port over plain HTTP
on **port 80**.

| File | Change |
|------|--------|
| `test-e2e-llm.yml`, `test-security-llm.yml` | tunnel → `flyctl proxy 3000:80 <app>.flycast -a <app>` |
| `staging-llm-service.toml`, `production-llm-service.toml` | `force_https = false` |
| `network-management.md` | document flycast:80 + `force_https=false` rationale |

express URLs (`http://<app>.flycast`) were already set by `#149`.

## Validated on the staging Fly VM

- Cold (stopped) machines **auto-start** via `flyctl proxy 3000:80 …flycast`; `GET /`
  returns **200** over the tunnel (the exact CI flow).
- express → llm over `http://staging-vb-llm-service.flycast` returns **200** from
  inside the express machine.
- After releasing the staging public IPs: the public `fly.dev` edge is **dead**
  (SSL error), flycast + express still **200**.

Staging is already fully locked down (flycast allocated, `force_https=false` deployed,
public IPs released, express repointed). Merging to `main` only exercises the
**staging** matrix, so main CI goes green on merge.

## Production runbook (manual — prod deploy is gated to the `production` branch)

Prod flycast IP is already allocated (`fdaa:3:5030:0:1::7`). When promoting to
production, do it in this order to avoid a brief 301 while express points at flycast:

1. Deploy `production-vb-llm-service` with `force_https = false` **first**
   (this PR's toml; or config-only with the current image).
2. Deploy `production-vb-express` (its flycast URL is already in the repo).
3. Release the prod public IPs:
   ```
   flyctl ips release 2a09:8280:1::149:ee0f:0 -a production-vb-llm-service
   flyctl ips release 66.241.124.248        -a production-vb-llm-service
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
