### PR TITLE
fix(ci): drop private llm-service from public-edge security matrix

### DIFF
--- a/.github/workflows/test-security-api.yml
+++ b/.github/workflows/test-security-api.yml
@@ -30,8 +30,9 @@ jobs:
       matrix:
         environment: ${{ fromJSON(github.event_name == 'workflow_run' && format('["{0}"]', github.event.workflow_run.head_branch == 'production' && 'production' || 'staging') || inputs.environment && inputs.environment != 'all' && format('["{0}"]', inputs.environment) || '["staging", "production"]') }}
         service:
+          # vb-llm-service is private-only (no public fly.dev edge); its no-key/wrong-key
+          # auth checks run over the flycast tunnel in test-security-llm.yml
           - vb-express
-          - vb-llm-service
           - vb-storage-service
           - vb-email-service
           - email-subscription-service

--- a/scripts/shell/test-llm-security.sh
+++ b/scripts/shell/test-llm-security.sh
@@ -8,7 +8,32 @@ MAX_NUM_OUTPUTS=10
 REQUESTED_NUM_OUTPUTS=15
 FAILED=0
 
-echo "Testing llm-service numOutputs clamp: ${LLM_SERVICE_URL}"
+PING_URL="${LLM_SERVICE_URL}/api/__ping"
+
+echo "Testing llm-service security: ${LLM_SERVICE_URL}"
+
+echo ""
+echo "Test: GET /api/__ping without x-api-key — expect 401"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X GET "${PING_URL}")
+echo "Response code: ${HTTP_CODE}"
+if [ "${HTTP_CODE}" = "401" ] || [ "${HTTP_CODE}" = "403" ]; then
+  echo "✓ Passed: rejected request without api key"
+else
+  echo "✗ Failed: got ${HTTP_CODE} (expected 401 or 403)"
+  FAILED=1
+fi
+
+echo ""
+echo "Test: GET /api/__ping with incorrect x-api-key — expect 401"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X GET "${PING_URL}" \
+  -H "x-api-key: invalid-key-12345")
+echo "Response code: ${HTTP_CODE}"
+if [ "${HTTP_CODE}" = "401" ] || [ "${HTTP_CODE}" = "403" ]; then
+  echo "✓ Passed: rejected request with incorrect api key"
+else
+  echo "✗ Failed: got ${HTTP_CODE} (expected 401 or 403)"
+  FAILED=1
+fi
 
 echo ""
 echo "Test: POST /api/llm with numOutputs=${REQUESTED_NUM_OUTPUTS} — expect <= ${MAX_NUM_OUTPUTS} outputs"
@@ -41,7 +66,7 @@ fi
 
 echo ""
 if [ "${FAILED}" = "1" ]; then
-  echo "✗ llm-service numOutputs clamp check failed"
+  echo "✗ llm-service security checks failed"
   exit 1
 fi
-echo "✓ llm-service numOutputs clamp check passed"
+echo "✓ llm-service security checks passed"


### PR DESCRIPTION
## Why

Follow-up to #152. Locking `llm-service` to the private 6PN network (public IPs
released) also broke [`test-security-api`](https://github.com/iamharryliu/vigilant-broccoli/actions/runs/29835328550):
its matrix probed `https://<env>-vb-llm-service.fly.dev/api/__ping` expecting a 401,
but the hostname no longer resolves → `curl` exit 6 → job fails.

That workflow is a **public-edge** auth check; it's inapplicable to a service with no
public edge. `#152` had already fixed the other two llm workflows but missed this one
(as did #149).

## Change

- Drop `vb-llm-service` from the `test-security-api` matrix (with a comment so it isn't
  re-added).
- Preserve the lost coverage: add **no-key → 401** and **wrong-key → 401** checks on
  `/api/__ping` to `test-llm-security.sh`, which reaches llm-service over the flycast
  tunnel in `test-security-llm.yml`.

## Validated

Over the flycast tunnel against staging: `GET /api/__ping` returns **401** with no key
and with a wrong key; root `/` stays **200**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
