### PR TITLE
feat(vb-manager-next): Add GitHub Apps to quick links

### DIFF
--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/constants/quick-links.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/constants/quick-links.ts
@@ -129,6 +129,12 @@ const DEV_LINKS = [
     subgroup: LINK_GROUP_SUBGROUP.DEV,
   },
   {
+    label: GITHUB_LINK.APPS.NAME,
+    target: GITHUB_LINK.APPS.URL,
+    type: OPEN_TYPE.BROWSER,
+    subgroup: LINK_GROUP_SUBGROUP.DEV,
+  },
+  {
     label: GITHUB_LINK.ACTIONS_PRICING.NAME,
     target: GITHUB_LINK.ACTIONS_PRICING.URL,
     type: OPEN_TYPE.BROWSER,

--- a/projects/nx-workspace/libs/@vigilant-broccoli/links/src/index.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/links/src/index.ts
@@ -219,6 +219,10 @@ export const GITHUB_LINK = {
     NAME: 'GitHub Organizations Settings',
     URL: 'https://github.com/settings/organizations',
   },
+  APPS: {
+    NAME: 'GitHub Apps',
+    URL: 'https://github.com/settings/apps',
+  },
 } as const;
 
 export const AWS_LINK = {


### PR DESCRIPTION
## Summary
- Added a `GITHUB_LINK.APPS` entry (`https://github.com/settings/apps`) to the shared `@vigilant-broccoli/links` package
- Wired it into `vb-manager-next`'s Dev quick-links list, next to the other GitHub settings links

## Test plan
- [ ] Run `vb-manager-next` locally and confirm "GitHub Apps" appears in the Dev quick-links group and opens the correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)