### PR TITLE
refactor(agent-sandbox): Stop falling back to the shared GITHUB_TOKEN for git auth

### DIFF
--- a/infrastructure/agent-sandbox/load-env-from-vault.sh
+++ b/infrastructure/agent-sandbox/load-env-from-vault.sh
@@ -46,7 +46,7 @@ if [ -n "$AGENT_GH_APP_ID" ] && [ -n "$AGENT_GH_APP_PRIVATE_KEY" ]; then
   GH_TOKEN=$("${SCRIPT_DIR}/mint-github-app-token.sh" "$AGENT_GH_APP_ID" "$PEM_FILE")
 else
   rm -f "$PEM_FILE"
-  GH_TOKEN=$(echo "$SECRETS" | jq -r '.AGENT_GITHUB_TOKEN // .GITHUB_TOKEN // empty')
+  GH_TOKEN=$(echo "$SECRETS" | jq -r '.AGENT_GITHUB_TOKEN // empty')
 fi
 
 if [ -z "$CLAUDE_CODE_OAUTH_TOKEN" ]; then
@@ -58,7 +58,7 @@ if [ "${#CLAUDE_CODE_OAUTH_TOKEN}" -lt 100 ]; then
   exit 1
 fi
 if [ -z "$GH_TOKEN" ]; then
-  echo "WARNING: no GitHub App credentials (AGENT_GH_APP_ID + AGENT_GH_APP_PRIVATE_KEY), AGENT_GITHUB_TOKEN, or GITHUB_TOKEN found in Vault; sandbox will have read-only git access." >&2
+  echo "WARNING: no GitHub App credentials (AGENT_GH_APP_ID + AGENT_GH_APP_PRIVATE_KEY) or AGENT_GITHUB_TOKEN found in Vault; sandbox will have read-only git access." >&2
 fi
 
 cat > "$ENV_FILE" <<EOF


### PR DESCRIPTION
## Summary

- Drop the `GITHUB_TOKEN` tier from the agent sandbox's git-auth fallback chain in `load-env-from-vault.sh`.
- `GITHUB_TOKEN` is the Terraform GitHub provider PAT (Administration + Secrets RW, repo-scoped) — far broader than the sandbox should ever hold, and already shadowed in practice by the App creds (`AGENT_GH_APP_ID` + `AGENT_GH_APP_PRIVATE_KEY`) and `AGENT_GITHUB_TOKEN`, so this path was never reached.
- Fallback chain is now: GitHub App installation token → `AGENT_GITHUB_TOKEN` (repo-scoped, Contents/PRs/Workflows RW) → read-only git. The no-credentials warning message is updated to match.

## Test plan

- [x] `bash -n load-env-from-vault.sh` passes (syntax valid).
- [x] pre-commit hooks pass on the staged change.
- [ ] `pnpm agentic:dev-sandbox:up` still mints git auth via the App path (unchanged) — the removed branch only affects environments with neither App creds nor `AGENT_GITHUB_TOKEN` in Vault, which now fall through to read-only git as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)