### PR TITLE
fix(ci): Drop redundant local RabbitMQ rotation from secret-rotation:all

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "gcp:vm:vault:seal": "./infrastructure/terraform/packer/scripts/run-vault-seal.sh",
     "gcp:vm:vault:save-secrets-local": "./infrastructure/terraform/packer/scripts/run-vault-get-secrets.sh",
     "gcp:vm:vault:set-secrets": "./infrastructure/terraform/packer/scripts/run-vault-set-secrets.sh",
-    "secret-rotation:all": "pnpm secret-rotation:flyio && pnpm secret-rotation:gitea && pnpm secret-rotation:profile-deploy-key && pnpm secret-rotation:rabbitmq && gh workflow run ci-rotate-secrets --repo iamharryliu/vigilant-broccoli",
+    "secret-rotation:all": "pnpm secret-rotation:flyio && pnpm secret-rotation:gitea && pnpm secret-rotation:profile-deploy-key && gh workflow run ci-rotate-secrets --repo iamharryliu/vigilant-broccoli",
     "secret-rotation:flyio": "./infrastructure/terraform/packer/scripts/rotate-fly-token.sh",
     "secret-rotation:gitea": "./infrastructure/terraform/packer/scripts/rotate-gitea-token.sh",
     "secret-rotation:profile-deploy-key": "./scripts/ci/rotate-profile-deploy-key.sh",


### PR DESCRIPTION
## Summary

- `secret-rotation:all` chained `pnpm secret-rotation:rabbitmq` locally **and** dispatched the `ci-rotate-secrets` workflow, which itself rotates `RABBITMQ_CONNECTION_STRING` — so the RabbitMQ password was rotated twice per `all` run.
- Removed the local `secret-rotation:rabbitmq` step from the chain; the workflow remains the single rotation path for RabbitMQ.
- Left the standalone `pnpm secret-rotation:rabbitmq` script untouched for ad-hoc local use.

## Test plan

- [ ] `pnpm secret-rotation:all` runs flyio → gitea → profile-deploy-key locally, then dispatches `ci-rotate-secrets` (no local RabbitMQ step)
- [ ] `ci-rotate-secrets` workflow still rotates `RABBITMQ_CONNECTION_STRING` once and both Fly consumers pick up the new value
- [ ] `pnpm secret-rotation:rabbitmq` still works standalone for local rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)