### PR TITLE
enhancement(agent-sandbox): Run the dev-sandbox CLI in a persistent tmux session with auto mode and sonnet by default.

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -84,7 +84,7 @@ Useful infra-level CLI commands, runnable via `pnpm run <script>`.
 🤖 AGENTIC — DEV SANDBOX (attended; you drive the persistent container)
   agentic:dev-sandbox:up      Fetch tokens from Vault into .env, then build + start contained Claude sandbox
                                (set SANDBOX_VAULT_ENV_VARS=NAME1,NAME2 in infrastructure/agent-sandbox/.env to also inject those Vault secret keys)
-  agentic:dev-sandbox:cli     Open an interactive Claude session in the sandbox repo clone (fable; append --model <m> to override)
+  agentic:dev-sandbox:cli     Open an interactive Claude session in a persistent tmux session in the sandbox repo clone (auto mode, sonnet; --model <m> to override)
   agentic:dev-sandbox:shell   Open an interactive bash shell in the sandbox (dotfiles loaded)
   agentic:dev-sandbox:logs    Follow sandbox provisioning logs
   agentic:dev-sandbox:down    Stop the sandbox

--- a/infrastructure/agent-sandbox/dev-sandbox-cli.sh
+++ b/infrastructure/agent-sandbox/dev-sandbox-cli.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+CONTAINER=vb-agent-sandbox
+WORKDIR=/home/agent/vigilant-broccoli
+SESSION=cli
+
+MODEL=sonnet
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --model)
+      MODEL=$2
+      shift 2
+      ;;
+    --model=*)
+      MODEL="${1#*=}"
+      shift
+      ;;
+    *)
+      echo "Usage: pnpm agentic:dev-sandbox:cli [--model <model>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+exec docker exec -it -u agent -w "$WORKDIR" "$CONTAINER" \
+  tmux new-session -A -s "$SESSION" -c "$WORKDIR" \
+  "claude --permission-mode auto --model $MODEL"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "local:docker:restart": "docker compose -f infrastructure/local/docker-compose.yml restart",
     "local:docker:reload": "docker compose -f infrastructure/local/docker-compose.yml down && docker compose -f infrastructure/local/docker-compose.yml up -d",
     "agentic:dev-sandbox:up": "./infrastructure/agent-sandbox/load-env-from-vault.sh && docker compose -f infrastructure/agent-sandbox/docker-compose.yml up -d --build --force-recreate",
-    "agentic:dev-sandbox:cli": "docker exec -it -u agent -w /home/agent/vigilant-broccoli vb-agent-sandbox claude --dangerously-skip-permissions --model fable",
+    "agentic:dev-sandbox:cli": "./infrastructure/agent-sandbox/dev-sandbox-cli.sh",
     "agentic:dev-sandbox:shell": "docker exec -it -u agent -w /home/agent/vigilant-broccoli vb-agent-sandbox bash",
     "agentic:dev-sandbox:logs": "docker logs -f vb-agent-sandbox",
     "agentic:dev-sandbox:down": "docker compose -f infrastructure/agent-sandbox/docker-compose.yml down",


### PR DESCRIPTION
## Summary
- `pnpm agentic:dev-sandbox:cli` now launches Claude inside a **persistent tmux session** (`new-session -A -s cli`) in the sandbox — if your terminal drops, rerun the command to reattach to the live session instead of starting fresh.
- Defaults to the **sonnet** model (was `fable`), with a `--model <m>` flag to override (e.g. `pnpm agentic:dev-sandbox:cli --model opus`).
- Starts in **auto mode** (`--permission-mode auto`, the classifier-based mode), replacing the previous blanket `--dangerously-skip-permissions` bypass — the two are mutually exclusive permission modes.
- Extracts the logic into a new wrapper script `infrastructure/agent-sandbox/dev-sandbox-cli.sh` (matching the `--model` parsing convention already used by `fix-pr.sh`), since a default-plus-override model flag can't be expressed cleanly inline in `package.json`.
- Updates the `docs/cheatsheet.md` entry to reflect tmux / auto mode / sonnet.

## Test plan
- [x] `bash -n` + parse simulation: default (`sonnet`), `--model X`, `--model=X`, and bad-arg error path all resolve correctly.
- [x] Inside the running `vb-agent-sandbox` container: `claude` (v2.1.216) and `tmux` (3.3a) on PATH; `tmux new-session -A -s cli -c <workdir>` creates the session with the correct start directory.
- [ ] Interactive attach in a real TTY (`pnpm agentic:dev-sandbox:cli`) — needs a terminal, not exercised by the non-interactive smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)