### PR TITLE
docs: Give agentic:task:solve the same cleanup checklist as /refactor-code-cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@
 - [Git](./docs/GIT.md) — read first before committing or pushing
 - [network-management.md](./docs/infrastructure/network-management.md) — read first before changing DNS records, domains/subdomains, proxying, tunnels, or VPN
 - [nuance.md](./docs/nuance.md) — non-obvious bugs and quirks discovered in this repo; check before debugging something that looks like it shouldn't happen
+- [refactor-code-cleanup.md](./docs/refactor-code-cleanup.md) — cleanup checklist for `/refactor-code-cleanup`; unattended `agentic:task:solve` runs must apply it before finishing
 - Coding Conventions — this file
 - Folder Structure — this file
 

--- a/docs/refactor-code-cleanup.md
+++ b/docs/refactor-code-cleanup.md
@@ -1,0 +1,16 @@
+# Refactor & Code Cleanup Checklist
+
+Shared checklist behind `/refactor-code-cleanup`. Two triggers:
+
+- Manual — run `/refactor-code-cleanup` in an interactive session.
+- Automatic — unattended `agentic:task:solve` runs apply this before finishing, per [CLAUDE.md](../CLAUDE.md).
+
+## Checklist
+
+- Double check the implementation and perform necessary cleanups.
+- Reduce string literals by using consts. Skip styling-related strings (CSS values, Tailwind classes, inline style objects, color/sizing tokens) — leave those inline.
+- Remove unused imports and dead code — variables, functions, or exports that are never referenced.
+- Remove debug `console.log` statements left over from development.
+- Remove unnecessary comments — inline comments that just restate what the code clearly does.
+- Report if there are any critical issues with the implementation.
+- Give any recommendations that would significantly improve the implementation, if any.

--- a/setup/dotfiles/.claude/commands/refactor-code-cleanup.md
+++ b/setup/dotfiles/.claude/commands/refactor-code-cleanup.md
@@ -1,7 +1,1 @@
-- Double check implementation perform necessary cleanups
-- Try to reduce string literals by using consts. Skip styling-related strings (CSS values, Tailwind classes, inline style objects, color/sizing tokens) — leave those inline.
-- Remove unused imports and dead code — variables, functions, or exports that are never referenced.
-- Remove debug `console.log` statements left over from development.
-- Remove unnecessary comments — inline comments that just restate what the code clearly does.
-- Report if there are any critical issues with the implementation.
-- Give any recommendations that you think would significantly improve implementation if you have any.
+Review the current changes against the checklist in `docs/refactor-code-cleanup.md`, apply the cleanups, and report any critical issues or recommendations called out there.


### PR DESCRIPTION
## Summary

- Extracted the `/refactor-code-cleanup` checklist into `docs/refactor-code-cleanup.md` as a shared source of truth.
- Slimmed the `/refactor-code-cleanup` command down to a one-line pointer at that doc (manual trigger), matching the existing `update-readmes` command pattern.
- Added a Doc Map line in `CLAUDE.md` stating that unattended `agentic:task:solve` runs must apply the checklist before finishing — no changes needed to `solve-todo-runner.sh` since it already instructs the agent to follow CLAUDE.md conventions, and CLAUDE.md is auto-loaded into every session including the sandbox's headless `claude -p` runs.

## Test plan

- [ ] `/refactor-code-cleanup` in an interactive session still applies the checklist correctly.
- [ ] Run `pnpm agentic:task:solve --prompt "<test task>"` and confirm the resulting PR reflects the cleanup checklist (no stray console.logs, unused imports, etc.) before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)