### PR TITLE
chore(github-actions): Remove unused SOCKET_SERVER_CA_CERT env var

### DIFF
--- a/scripts/node/test-socket-server-security.mjs
+++ b/scripts/node/test-socket-server-security.mjs
@@ -1,7 +1,6 @@
 import { io } from 'socket.io-client';
 
 const URL = process.env.SOCKET_SERVER_URL;
-const CA_B64 = process.env.SOCKET_SERVER_CA_CERT;
 
 const APP = 'security-check';
 const PAYLOAD = { canary: 'should-not-be-delivered', ts: Date.now() };
@@ -23,14 +22,9 @@ if (!URL) {
   process.exit(2);
 }
 
-const tlsOpts = CA_B64
-  ? { ca: Buffer.from(CA_B64, 'base64'), checkServerIdentity: () => undefined }
-  : {};
-
 const baseOpts = {
   transports: ['websocket'],
   reconnection: false,
-  ...tlsOpts,
 };
 
 const awaitConnect = sock =>


### PR DESCRIPTION
## Summary
- `test-socket-server-security.mjs` read `process.env.SOCKET_SERVER_CA_CERT` to optionally supply a custom CA / bypass `checkServerIdentity`, but no workflow ever sets that env var — `test-security-socket-server.yml` only imports `SOCKET_SERVER_URL` from Vault.
- Removes the dead `CA_B64` / `tlsOpts` branch so the script only depends on env vars that are actually wired up.

## Test plan
- [ ] `test-security-socket-server` workflow run stays green (no behavior change — the branch removed was always a no-op since the env var was never set)