### PR TITLE
chore(terraform): Add pnpm tf:unlock script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "tf:apply": "eval $(./infrastructure/terraform/scripts/load-vault-tf-env.sh) && cd infrastructure/terraform && terraform apply && cd ../.. && ./infrastructure/terraform/scripts/post-apply.sh",
     "tf:post-apply": "./infrastructure/terraform/scripts/post-apply.sh",
     "tf:output": "cd infrastructure/terraform && terraform output",
+    "tf:unlock": "eval $(./infrastructure/terraform/scripts/load-vault-tf-env.sh) && cd infrastructure/terraform && terraform force-unlock",
     "oci:vm:ssh": "./scripts/shell/oci-ssh.sh oci_vm_public_ip",
     "oci:vm:sync-socket-token": "./infrastructure/terraform/packer/scripts/sync-socket-server-token.sh",
     "oci:gitea:ssh": "./scripts/shell/oci-ssh.sh oci_gitea_public_ip",


### PR DESCRIPTION
## Summary

- Adds a `pnpm tf:unlock` script (`package.json`) wrapping `terraform force-unlock`, following the same `load-vault-tf-env.sh` + `cd infrastructure/terraform` pattern as the existing `tf:plan`/`tf:apply`/`tf:output` scripts.
- Motivated by needing to clear a stuck Terraform Cloud state lock (`workspace already locked`) left behind by an interrupted `plan`/`apply` — previously required typing the full invocation by hand.

## Test plan

- [x] `pnpm tf:unlock <lock-id>` invoked locally to clear a real stuck lock; resolved `terraform plan` failing with "Error acquiring the state lock".
- [ ] Note: for this repo's Terraform Cloud (`cloud` block) backend, `force-unlock`'s expected lock ID is the `<org>/<workspace>` string, not the UUID shown in `Lock Info` — worth remembering if this ever needs debugging again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)