### PR TITLE
fix(docs-md): Route internal note links through SPA navigation

### DIFF
--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/components/DocsExplorer.tsx
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/components/DocsExplorer.tsx
@@ -63,7 +63,10 @@ export interface ViewModeOption {
 interface DocsExplorerProps {
   nodes: DocsNode[];
   getContent: (path: string) => Promise<string>;
-  renderContent?: (content: string) => ReactNode;
+  renderContent?: (
+    content: string,
+    navigate: (path: string) => void,
+  ) => ReactNode;
   search?: (query: string) => Promise<DocsSearchResult[]>;
   urlSync?: DocsExplorerUrlSync;
   sidebarTitle?: string;
@@ -333,7 +336,11 @@ export const DocsExplorer = ({
                         <DropdownMenu.Item
                           key={mode.value}
                           onSelect={() => onViewModeChange?.(mode.value)}
-                          className={currentViewMode === mode.value ? 'font-semibold' : ''}
+                          className={
+                            currentViewMode === mode.value
+                              ? 'font-semibold'
+                              : ''
+                          }
                         >
                           {mode.label}
                         </DropdownMenu.Item>
@@ -362,7 +369,7 @@ export const DocsExplorer = ({
               </DropdownMenu.Root>
             </div>
             {renderContent ? (
-              renderContent(content)
+              renderContent(content, selectFile)
             ) : (
               <pre className="whitespace-pre-wrap px-4 sm:px-6 py-4 text-sm">
                 {content}

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/checklist-viewer.tsx
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/checklist-viewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState, type JSX } from 'react';
 import { marked, Tokens } from 'marked';
+import { createNoteLinkClickHandler } from './note-links';
 
 const STORAGE_PREFIX = 'docs-checklist:';
 const INTRO_PREFIX = 'intro';
@@ -37,6 +38,7 @@ const CLS = {
 interface ChecklistViewerProps {
   content: string;
   filePath: string;
+  onNavigate?: (path: string) => void;
 }
 
 interface ChecklistItem {
@@ -164,10 +166,19 @@ interface ItemRowProps {
   item: ChecklistItem;
   checked: Set<string>;
   toggle: (id: string) => void;
+  filePath: string;
+  onNavigate?: (path: string) => void;
 }
 
-const ItemRow = ({ item, checked, toggle }: ItemRowProps) => {
+const ItemRow = ({
+  item,
+  checked,
+  toggle,
+  filePath,
+  onNavigate,
+}: ItemRowProps) => {
   const isChecked = checked.has(item.id);
+  const handleLinkClick = createNoteLinkClickHandler(filePath, onNavigate);
   return (
     <li className="list-none">
       <label className={CLS.ROW_LABEL}>
@@ -183,6 +194,7 @@ const ItemRow = ({ item, checked, toggle }: ItemRowProps) => {
           onClickCapture={e => {
             if ((e.target as HTMLElement).tagName === ANCHOR_TAG) {
               e.stopPropagation();
+              handleLinkClick(e);
             }
           }}
         />
@@ -195,6 +207,8 @@ const ItemRow = ({ item, checked, toggle }: ItemRowProps) => {
               item={child}
               checked={checked}
               toggle={toggle}
+              filePath={filePath}
+              onNavigate={onNavigate}
             />
           ))}
         </ul>
@@ -203,7 +217,11 @@ const ItemRow = ({ item, checked, toggle }: ItemRowProps) => {
   );
 };
 
-export function ChecklistViewer({ content, filePath }: ChecklistViewerProps) {
+export function ChecklistViewer({
+  content,
+  filePath,
+  onNavigate,
+}: ChecklistViewerProps) {
   const parsed = useMemo(() => parseContent(content), [content]);
   const [checked, setChecked] = useState<Set<string>>(() => new Set());
 
@@ -257,6 +275,8 @@ export function ChecklistViewer({ content, filePath }: ChecklistViewerProps) {
                 item={item}
                 checked={checked}
                 toggle={toggle}
+                filePath={filePath}
+                onNavigate={onNavigate}
               />
             ))}
           </ul>
@@ -287,6 +307,8 @@ export function ChecklistViewer({ content, filePath }: ChecklistViewerProps) {
                       item={item}
                       checked={checked}
                       toggle={toggle}
+                      filePath={filePath}
+                      onNavigate={onNavigate}
                     />
                   ))}
                 </ul>

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/docs-viewer.tsx
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/docs-viewer.tsx
@@ -89,22 +89,29 @@ export function DocsViewer({
 
   const canEdit = Boolean(saveContent && activeFile);
 
-  const viewModeOptions = (Object.values(VIEW_MODE) as ViewMode[]).map(mode => ({
-    label: MODE_LABEL[mode],
-    value: mode,
-  }));
+  const viewModeOptions = (Object.values(VIEW_MODE) as ViewMode[]).map(
+    mode => ({
+      label: MODE_LABEL[mode],
+      value: mode,
+    }),
+  );
 
-  const renderContent = (content: string) => (
+  const renderContent = (content: string, navigate: (path: string) => void) => (
     <div className="flex flex-col h-full">
       <div className="flex-1 min-h-0">
         {viewMode === VIEW_MODE.CHECKLIST ? (
-          <ChecklistViewer content={content} filePath={activeFile} />
+          <ChecklistViewer
+            content={content}
+            filePath={activeFile}
+            onNavigate={navigate}
+          />
         ) : (
           <MarkdownViewer
             content={content}
             filePath={activeFile}
             saveContent={saveContent}
             editTrigger={editTrigger}
+            onNavigate={navigate}
           />
         )}
       </div>
@@ -128,7 +135,7 @@ export function DocsViewer({
       emptyMessage={COPY.EMPTY}
       onEdit={canEdit ? () => setEditTrigger(t => t + 1) : undefined}
       viewModes={viewModeOptions}
-      onViewModeChange={(mode) => updateViewMode(mode as ViewMode)}
+      onViewModeChange={mode => updateViewMode(mode as ViewMode)}
       currentViewMode={viewMode}
     />
   );

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/markdown-viewer.tsx
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/markdown-viewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import { createNoteLinkClickHandler } from './note-links';
 
 const CLS = {
   ROOT: 'w-full h-full overflow-auto',
@@ -30,6 +31,7 @@ interface MarkdownViewerProps {
   filePath?: string;
   saveContent?: (path: string, content: string) => Promise<void>;
   editTrigger?: number;
+  onNavigate?: (path: string) => void;
 }
 
 export function MarkdownViewer({
@@ -37,6 +39,7 @@ export function MarkdownViewer({
   filePath,
   saveContent,
   editTrigger,
+  onNavigate,
 }: MarkdownViewerProps) {
   const [html, setHtml] = useState('');
   const [isEditing, setIsEditing] = useState(false);
@@ -123,7 +126,11 @@ export function MarkdownViewer({
 
   return (
     <div className={CLS.ROOT}>
-      <div className={CLS.PROSE} dangerouslySetInnerHTML={{ __html: html }} />
+      <div
+        className={CLS.PROSE}
+        dangerouslySetInnerHTML={{ __html: html }}
+        onClick={createNoteLinkClickHandler(filePath ?? '', onNavigate)}
+      />
     </div>
   );
 }

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/note-links.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/note-links.ts
@@ -1,0 +1,44 @@
+import type { MouseEvent } from 'react';
+
+const EXTERNAL_OR_HASH_HREF_RE = /^([a-z][a-z0-9+.-]*:|#)/i;
+const PATH_SEP = '/';
+const CURRENT_SEGMENT = '.';
+const PARENT_SEGMENT = '..';
+
+export const resolveNoteLink = (
+  fromPath: string,
+  href: string,
+): string | null => {
+  if (!href || EXTERNAL_OR_HASH_HREF_RE.test(href)) return null;
+
+  const rawPath = href.split('#')[0];
+  if (!rawPath) return null;
+
+  const segments = [
+    ...fromPath.split(PATH_SEP).slice(0, -1),
+    ...rawPath.split(PATH_SEP),
+  ];
+
+  const resolved: string[] = [];
+  for (const segment of segments) {
+    if (!segment || segment === CURRENT_SEGMENT) continue;
+    if (segment === PARENT_SEGMENT) resolved.pop();
+    else resolved.push(segment);
+  }
+
+  return resolved.join(PATH_SEP);
+};
+
+export const createNoteLinkClickHandler =
+  (filePath: string, onNavigate?: (path: string) => void) =>
+  (event: MouseEvent<HTMLElement>) => {
+    if (!onNavigate) return;
+    const anchor = (event.target as HTMLElement).closest('a');
+    if (!anchor) return;
+    const href = anchor.getAttribute('href');
+    if (!href) return;
+    const target = resolveNoteLink(filePath, href);
+    if (target === null) return;
+    event.preventDefault();
+    onNavigate(target);
+  };


### PR DESCRIPTION
## Summary
- `docs.harryliu.dev` (the `docs-md` app) has no server-side routing — content loads via a `?file=` query param — but `MarkdownViewer`/`ChecklistViewer` rendered note-to-note links as plain `<a href>` tags, so clicking one triggered a real browser navigation to a URL with no matching route (a dead link).
- Adds `resolveNoteLink`/`createNoteLinkClickHandler` (`react-utility/src/lib/note-links.ts`) to resolve a clicked link's relative `href` against the current note's path and intercept the click, letting external/`http(s)`/`mailto`/hash-only links fall through to normal browser behavior.
- Threads the SPA's existing `selectFile` navigation from `DocsExplorer` → `DocsViewer`'s `renderContent` → both `MarkdownViewer` and `ChecklistViewer`, so it works for every app that renders `DocsViewer` (`docs-md`, `journal`, `vb-manager-next`).

## Test plan
- [x] `tsc --noEmit` clean on `react-lib`, `react-utility`, `docs-md`
- [x] `nx lint` clean (no new warnings) on `react-lib`, `react-utility`, `docs-md`
- [x] `nx build` succeeds for `docs-md`, `journal`, `vb-manager-next`
- [x] Manually traced link resolution for real note links in the repo (packlist → toiletry-packlist, outdoor-packlist → packlist#utility, cross-directory links) — all resolve to the correct file path
- [ ] Live click-through in a browser (not done — no browser tooling available this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)