### PR TITLE
fix(common-js): Update DeepSeek model IDs to the currently supported names

### DIFF
--- a/projects/nx-workspace/libs/@vigilant-broccoli/common-js/src/lib/llm/llm.consts.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/common-js/src/lib/llm/llm.consts.ts
@@ -23,8 +23,8 @@ export const ANTHROPIC_MODEL = {
 export const ANTHROPIC_MODELS = Object.values(ANTHROPIC_MODEL);
 
 export const DEEPSEEK_MODEL = {
-  DEEP_SEEK: 'deepseek-chat',
-  DEEP_SEEK_REASONER: 'deepseek-reasoner',
+  DEEP_SEEK_V4_PRO: 'deepseek-v4-pro',
+  DEEP_SEEK_V4_FLASH: 'deepseek-v4-flash',
 } as const;
 export const DEEPSEEK_MODELS = Object.values(DEEPSEEK_MODEL);
 
@@ -107,11 +107,11 @@ export const LLM_MODEL_METADATA: Record<string, LLMModelMetadata> = {
   },
 
   // DeepSeek Models
-  [DEEPSEEK_MODEL.DEEP_SEEK]: {
+  [DEEPSEEK_MODEL.DEEP_SEEK_V4_PRO]: {
     hasImageInputSupport: false,
     hasImageOutputSupport: false,
   },
-  [DEEPSEEK_MODEL.DEEP_SEEK_REASONER]: {
+  [DEEPSEEK_MODEL.DEEP_SEEK_V4_FLASH]: {
     hasImageInputSupport: false,
     hasImageOutputSupport: false,
   },


### PR DESCRIPTION
## Summary
- `scripts/shell/test-llm-e2e.sh` run against `llm-service` with `MODEL=deepseek-chat` failed with `400 The supported API model names are deepseek-v4-pro or deepseek-v4-flash, but you passed deepseek-chat`
- DeepSeek's API has retired `deepseek-chat`/`deepseek-reasoner`; updated `DEEPSEEK_MODEL` in `projects/nx-workspace/libs/@vigilant-broccoli/common-js/src/lib/llm/llm.consts.ts` (and its `LLM_MODEL_METADATA` keys) to `deepseek-v4-pro`/`deepseek-v4-flash`
- No other code referenced the old constant names directly, so this is a self-contained fix

## Test plan
- [x] `nx run-many -t build -p @vigilant-broccoli/llm-tools llm-service` builds cleanly
- [ ] Run `scripts/shell/test-llm-e2e.sh` with `MODEL=deepseek-v4-pro` (or `deepseek-v4-flash`) against a running `llm-service` instance to confirm the e2e test passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)