### PR TITLE
feat(docs-md): Add full-text content search alongside filename search

### DIFF
--- a/projects/nx-workspace/apps/ui/docs-md/src/app/github-docs.ts
+++ b/projects/nx-workspace/apps/ui/docs-md/src/app/github-docs.ts
@@ -10,6 +10,8 @@ const ITEM_TYPE_BLOB = 'blob';
 const ITEM_TYPE_TREE = 'tree';
 const MD_EXT = '.md';
 const PATH_SEP = '/';
+const CONTENT_FETCH_CONCURRENCY = 8;
+const EXCERPT_CONTEXT_CHARS = 100;
 
 interface GithubTreeItem {
   path: string;
@@ -23,6 +25,8 @@ interface GithubTreeResponse {
 
 let treeCache: DocsNode[] | null = null;
 let flatFilesCache: { name: string; path: string }[] | null = null;
+let contentCache: Map<string, string> | null = null;
+let contentCachePromise: Promise<Map<string, string>> | null = null;
 
 const buildTree = (items: GithubTreeItem[]): DocsNode[] => {
   const root: DocsNode[] = [];
@@ -108,20 +112,96 @@ export const fetchContent = async (path: string): Promise<string> => {
   return res.text();
 };
 
+const fetchAllFileContents = (): Promise<Map<string, string>> => {
+  if (contentCache) return Promise.resolve(contentCache);
+  if (contentCachePromise) return contentCachePromise;
+
+  contentCachePromise = (async () => {
+    if (!flatFilesCache) await fetchStructure();
+    const files = flatFilesCache ?? [];
+    const cache = new Map<string, string>();
+    const queue = [...files];
+
+    const worker = async () => {
+      for (let file = queue.shift(); file; file = queue.shift()) {
+        try {
+          cache.set(file.path, await fetchContent(file.path));
+        } catch {
+          // skip files that fail to fetch; they're just absent from content search
+        }
+      }
+    };
+
+    await Promise.all(
+      Array.from({ length: CONTENT_FETCH_CONCURRENCY }, worker),
+    );
+    contentCache = cache;
+    return cache;
+  })();
+
+  return contentCachePromise;
+};
+
+const getExcerpt = (
+  content: string,
+  index: number,
+  matchLength: number,
+): string => {
+  const start = Math.max(0, index - EXCERPT_CONTEXT_CHARS / 2);
+  const end = Math.min(
+    content.length,
+    index + matchLength + EXCERPT_CONTEXT_CHARS / 2,
+  );
+  const prefix = start > 0 ? '...' : '';
+  const suffix = end < content.length ? '...' : '';
+  return `${prefix}${content.slice(start, end)}${suffix}`;
+};
+
 export const searchDocs = async (
   query: string,
 ): Promise<DocsSearchResult[]> => {
   if (!flatFilesCache) await fetchStructure();
   const files = flatFilesCache ?? [];
-  const fuse = new Fuse(files, {
+
+  const filenameFuse = new Fuse(files, {
     keys: ['name', 'path'],
     threshold: 0.4,
     includeScore: true,
   });
-  return fuse.search(query).map(r => ({
-    name: r.item.name,
-    path: r.item.path,
-    matchType: 'filename' as const,
-    score: r.score ?? 0,
-  }));
+  const filenameMatches: DocsSearchResult[] = filenameFuse
+    .search(query)
+    .map(r => ({
+      name: r.item.name,
+      path: r.item.path,
+      matchType: 'filename' as const,
+      score: r.score ?? 0,
+    }));
+
+  const filenameMatchPaths = new Set(filenameMatches.map(m => m.path));
+  const contents = await fetchAllFileContents();
+  const lowerQuery = query.toLowerCase();
+  const contentMatches: DocsSearchResult[] = files
+    .filter(f => !filenameMatchPaths.has(f.path) && contents.has(f.path))
+    .map(f => {
+      const content = contents.get(f.path) ?? '';
+      return {
+        ...f,
+        content,
+        index: content.toLowerCase().indexOf(lowerQuery),
+      };
+    })
+    .filter(f => f.index !== -1)
+    .sort((a, b) => a.index - b.index)
+    .map(f => ({
+      name: f.name,
+      path: f.path,
+      matchType: 'content' as const,
+      score: f.index / f.content.length,
+      excerpt: getExcerpt(f.content, f.index, query.length),
+    }));
+
+  return [
+    ...filenameMatches.sort((a, b) => a.score - b.score),
+    ...contentMatches,
+  ];
 };


### PR DESCRIPTION
## Summary
- `searchDocs` in the `docs-md` app previously only fuzzy-matched a note's filename/path (via fuse.js), so a term that only appears in a note's body (e.g. "mantecare" in `cooking-lingo.md`) was unfindable.
- Adds content search: fetches every note's raw text once (capped at 8 concurrent requests to `raw.githubusercontent.com`, cached in-memory per session, with concurrent-call dedup so a second search mid-fetch reuses the same in-flight fetch instead of starting a duplicate one), then does a case-insensitive substring search over it.
- Filename matches are ranked first (unchanged fuzzy behavior); content matches follow, each with a highlighted excerpt. The shared `DocsExplorer` UI component already supported `matchType: 'content'` and excerpts — only the search function needed the extra logic.
- Along the way, ruled out `fuse.js` fuzzy-matching over full document bodies: it's tuned for short strings and either missed distant matches or ranked unrelated files above the real match, so content matching uses a plain substring search instead.

## Test plan
- [x] `nx lint docs-md` passes
- [x] `nx build docs-md` passes
- [x] Ran `searchDocs('mantecare')` against live GitHub content — returns only `cooking-lingo.md` with correct excerpt
- [x] Ran `searchDocs('react hooks')` — filename match ranks first, content matches follow with sensible excerpts
- [x] Verified two concurrent searches before the content cache is warm share one fetch instead of duplicating it

🤖 Generated with [Claude Code](https://claude.com/claude-code)