### PR TITLE
fix(docs-md): TOC/anchor jumps + document the DocsExplorer feature

### DIFF
--- a/projects/nx-workspace/apps/ui/docs-md/src/app/app.tsx
+++ b/projects/nx-workspace/apps/ui/docs-md/src/app/app.tsx
@@ -9,7 +9,11 @@ const getFileParam = () =>
 const setFileParam = (path: string) => {
   const params = new URLSearchParams(window.location.search);
   params.set(FILE_PARAM, path);
-  window.history.pushState(null, '', `?${params.toString()}`);
+  window.history.pushState(
+    null,
+    '',
+    `?${params.toString()}${window.location.hash}`,
+  );
 };
 
 export function App() {

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/docs-md/page.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/docs-md/page.tsx
@@ -75,7 +75,9 @@ function DocsPageContent() {
       set: (path: string) => {
         const params = new URLSearchParams(searchParams.toString());
         params.set(FILE_PARAM, path);
-        router.push(`?${params.toString()}`, { scroll: false });
+        router.push(`?${params.toString()}${window.location.hash}`, {
+          scroll: false,
+        });
       },
     }),
     [searchParams, router],

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/docs/features/docs-explorer.md
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/docs/features/docs-explorer.md
@@ -11,7 +11,7 @@
 ## DocsExplorer Props
 
 - `nodes`, `getContent(path)` — tree + file fetch
-- `renderContent(content, navigate)` — how the selected file renders; `DocsViewer` supplies the markdown/checklist switch here
+- `renderContent(content, navigate, sourcePaths)` — how the selected file(s) render; `sourcePaths` is `[selectedPath]` normally, or every checked path in multi-select mode; `DocsViewer` supplies the markdown/checklist switch here
 - `search(query)` — optional; enables the search box
 - `urlSync: { get, set }` — syncs selected file to the URL instead of component state alone
 - `viewModes`, `currentViewMode`, `onViewModeChange` — populate the content-pane dropdown
@@ -28,13 +28,17 @@
 
 - View mode (`markdown` / `checklist`) persists in `localStorage` (`docs-md:view-mode`) independent of which file is open; defaults to markdown
 - Checklist view renders the full document exactly like markdown view — only top-level lists become checkboxes; tables, prose, code, headings pass through unchanged
-- Checkbox state persists per file (`localStorage`, key `docs-checklist:<path>`), keyed by structural position (`list<N>.<itemIndex>`, nested via `.l.`) — not content, so state can go stale if list ordering changes
+- Checkbox state persists per file (`localStorage`, key `docs-checklist:<path>`), keyed by structural position (`list<N>.<itemIndex>`, nested via `.l.`) — not content, so state can go stale if list ordering changes; in aggregate mode (below) the key is a composite of every selected path joined with `|`, so the same set of files always shares one saved state
 - All rendered HTML (both view modes) is sanitized with DOMPurify before injection
 - Relative markdown links are intercepted and routed through `urlSync`/`onNavigate` instead of a real browser navigation — neither app has a per-file route, so a plain `<a href>` navigation would 404 or reload the whole app
 - Headings get GitHub-style slug `id`s (`markdown-config.ts`'s `createHeadingRenderer`, via `github-slugger`) so `[Section](#section)`-style TOC/cross-file anchors resolve — `marked` v5+ no longer assigns heading ids on its own
 - `createHeadingRenderer()` builds a fresh renderer+slugger per parse call rather than a shared/global one — `marked`'s own heading-id extensions track dedup state in module scope, which breaks under React Strict Mode's double-invoked effects/memos (two overlapping parses for the same content stomp on each other's dedup reset) and under any real overlapping parse (e.g. switching files before the previous parse settles)
 - Both apps' `urlSync.set()` must preserve `window.location.hash` when rebuilding the URL — it's easy to accidentally drop the hash (e.g. rebuilding the URL from just the query params) since `DocsExplorer` calls `urlSync.set()` on initial mount too, even when just echoing back the file it already read from the URL
+- Cross-file links with a section anchor (`./file.md#section`) carry the hash through: `resolveNoteLink` keeps it on the resolved target, and `selectFile` only writes `window.location.hash` when the caller actually supplied one — plain path selections (tree click, search result, initial URL sync) leave the hash alone, since the initial-mount sync always calls `selectFile` with a bare path and would otherwise clobber a hash that was already correctly in the URL from a direct link
+- Known gap: selecting a _different_ file via the tree or search doesn't clear a leftover hash from the previous file — harmless (no matching heading means `scrollToUrlHash` no-ops) but the stale fragment stays visible in the URL until something overwrites it
 - `scrollToUrlHash()` (`note-links.ts`) runs after content renders in both viewers — the browser's native scroll-to-fragment only fires around initial page load, which is well before this SPA's async-fetched content (and its heading ids) exist in the DOM
+- Checking multiple files in the tree (checkbox next to each file) switches the content pane to an aggregate view: their contents join with `\n\n---\n\n`, with a mode toggle (in the dropdown) for whether to keep every file's headings as-is, drop just each file's leading `#` title, or strip all headings — `saveContent`/edit is disabled in this mode
+- Note-link resolution in aggregate mode is imprecise: `MarkdownViewer` resolves relative links against only the first selected file's directory (wrong for links belonging to a later file in a different directory), and `ChecklistViewer` gets the composite `aggregate:path1|path2` string as its "path", which isn't a real path at all — relative link clicks there resolve incorrectly
 - Edit mode swaps content for a plain `<textarea>` (no live preview); content-pane dropdown also has "Copy markdown" (always) and "Back to files" (mobile only)
 - Search is debounced 300ms; Arrow keys move focus between the search box and result list, Escape clears the query
 - Mobile collapses to two full-width panels (sidebar/content) toggled by a back button — no side-by-side layout below `md:`

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/docs/features/docs-explorer.md
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/docs/features/docs-explorer.md
@@ -31,6 +31,10 @@
 - Checkbox state persists per file (`localStorage`, key `docs-checklist:<path>`), keyed by structural position (`list<N>.<itemIndex>`, nested via `.l.`) — not content, so state can go stale if list ordering changes
 - All rendered HTML (both view modes) is sanitized with DOMPurify before injection
 - Relative markdown links are intercepted and routed through `urlSync`/`onNavigate` instead of a real browser navigation — neither app has a per-file route, so a plain `<a href>` navigation would 404 or reload the whole app
+- Headings get GitHub-style slug `id`s (`markdown-config.ts`'s `createHeadingRenderer`, via `github-slugger`) so `[Section](#section)`-style TOC/cross-file anchors resolve — `marked` v5+ no longer assigns heading ids on its own
+- `createHeadingRenderer()` builds a fresh renderer+slugger per parse call rather than a shared/global one — `marked`'s own heading-id extensions track dedup state in module scope, which breaks under React Strict Mode's double-invoked effects/memos (two overlapping parses for the same content stomp on each other's dedup reset) and under any real overlapping parse (e.g. switching files before the previous parse settles)
+- Both apps' `urlSync.set()` must preserve `window.location.hash` when rebuilding the URL — it's easy to accidentally drop the hash (e.g. rebuilding the URL from just the query params) since `DocsExplorer` calls `urlSync.set()` on initial mount too, even when just echoing back the file it already read from the URL
+- `scrollToUrlHash()` (`note-links.ts`) runs after content renders in both viewers — the browser's native scroll-to-fragment only fires around initial page load, which is well before this SPA's async-fetched content (and its heading ids) exist in the DOM
 - Edit mode swaps content for a plain `<textarea>` (no live preview); content-pane dropdown also has "Copy markdown" (always) and "Back to files" (mobile only)
 - Search is debounced 300ms; Arrow keys move focus between the search box and result list, Escape clears the query
 - Mobile collapses to two full-width panels (sidebar/content) toggled by a back button — no side-by-side layout below `md:`

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/docs/features/docs-explorer.md
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/docs/features/docs-explorer.md
@@ -1,0 +1,39 @@
+# DocsExplorer
+
+`libs/@vigilant-broccoli/react-lib` — file-tree + search shell for browsing markdown docs. Markdown/checklist rendering and edit mode are layered on top by `react-utility`'s `DocsViewer`.
+
+## Exports
+
+- `DocsExplorer` (react-lib) — tree/search shell, content-agnostic
+- `DocsNode`, `DocsSearchResult` (react-lib types)
+- `DocsViewer`, `FILE_PARAM` (react-utility) — wraps `DocsExplorer` with markdown + checklist view modes and edit mode; `FILE_PARAM` (`'file'`) is the URL query key both consuming apps sync the selected path through
+
+## DocsExplorer Props
+
+- `nodes`, `getContent(path)` — tree + file fetch
+- `renderContent(content, navigate)` — how the selected file renders; `DocsViewer` supplies the markdown/checklist switch here
+- `search(query)` — optional; enables the search box
+- `urlSync: { get, set }` — syncs selected file to the URL instead of component state alone
+- `viewModes`, `currentViewMode`, `onViewModeChange` — populate the content-pane dropdown
+- `onEdit` — adds an Edit item to the content-pane dropdown
+- `sidebarTitle`, `searchPlaceholder`, `emptyMessage` — copy overrides
+
+## DocsViewer Props
+
+- `getStructure`, `getContent`, `search` — same contracts as DocsExplorer
+- `saveContent(path, content)` — optional; its presence alone enables the Edit action
+- `urlSync` — forwarded to DocsExplorer
+
+## Behaviour
+
+- View mode (`markdown` / `checklist`) persists in `localStorage` (`docs-md:view-mode`) independent of which file is open; defaults to markdown
+- Checklist view renders the full document exactly like markdown view — only top-level lists become checkboxes; tables, prose, code, headings pass through unchanged
+- Checkbox state persists per file (`localStorage`, key `docs-checklist:<path>`), keyed by structural position (`list<N>.<itemIndex>`, nested via `.l.`) — not content, so state can go stale if list ordering changes
+- All rendered HTML (both view modes) is sanitized with DOMPurify before injection
+- Relative markdown links are intercepted and routed through `urlSync`/`onNavigate` instead of a real browser navigation — neither app has a per-file route, so a plain `<a href>` navigation would 404 or reload the whole app
+- Edit mode swaps content for a plain `<textarea>` (no live preview); content-pane dropdown also has "Copy markdown" (always) and "Back to files" (mobile only)
+- Search is debounced 300ms; Arrow keys move focus between the search box and result list, Escape clears the query
+- Mobile collapses to two full-width panels (sidebar/content) toggled by a back button — no side-by-side layout below `md:`
+- Search isn't implemented in these libs — each consuming app supplies its own `search` function:
+  - `docs-md` app: fetches every note body once (8-way concurrency cap, in-memory per-session cache, in-flight fetch dedup so overlapping searches don't double-fetch), plain substring content match + `fuse.js` fuzzy filename match
+  - `vb-manager-next`: server route re-reads local disk (`~/vigilant-broccoli/notes`) on every request, `fuse.js` fuzzy match for both filename and content — its content match has no `ignoreLocation`, so (unlike docs-md) it can miss matches far into long documents

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/components/DocsExplorer.tsx
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/components/DocsExplorer.tsx
@@ -37,6 +37,7 @@ const INDENT_BASE_PX = 8;
 const LEADING_HEADING_RE = /^#\s[^\n]*\n+/;
 const ALL_HEADINGS_RE = /^#{1,6}\s[^\n]*\n+/gm;
 const AGGREGATE_SEPARATOR = '\n\n---\n\n';
+const HASH_SEP = '#';
 
 const stripLeadingHeading = (content: string) =>
   content.replace(LEADING_HEADING_RE, '');
@@ -207,7 +208,13 @@ export const DocsExplorer = ({
   }, [selectedPaths, hasSelection, getContent]);
 
   const selectFile = useCallback(
-    async (path: string) => {
+    async (pathWithHash: string) => {
+      const [path, hash] = pathWithHash.split(HASH_SEP);
+      // Only touch the hash when the caller supplied one (a resolved cross-file
+      // link) — plain path selections (tree, search, initial URL sync) leave
+      // whatever's already in the URL alone, so a direct load of `?file=...#foo`
+      // isn't clobbered by the initial mount echoing the file back into the URL.
+      if (hash !== undefined) window.location.hash = hash;
       setSelectedPaths([]);
       setSelectedPath(path);
       setMobilePanel('content');

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/checklist-viewer.tsx
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/checklist-viewer.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
-import { marked, Tokens } from 'marked';
+import type { MarkedOptions, Tokens } from 'marked';
 import DOMPurify from 'dompurify';
-import { createNoteLinkClickHandler } from './note-links';
+import { createHeadingRenderer, marked } from './markdown-config';
+import { createNoteLinkClickHandler, scrollToUrlHash } from './note-links';
 
 const STORAGE_PREFIX = 'docs-checklist:';
 const LIST_ID_PREFIX = 'list';
 const NESTED_LIST_SUFFIX = 'l';
-const PARSER_OPTS = { async: false } as const;
 const STRIP_P_RE = /^<p>|<\/p>\n?$/g;
 const ANCHOR_TAG = 'A';
 
@@ -48,17 +48,15 @@ type ContentBlock =
   | { kind: 'html'; html: string }
   | { kind: 'list'; items: ChecklistItem[] };
 
-const inlineHtml = (tokens: Tokens.Generic[]): string =>
+const inlineHtml = (tokens: Tokens.Generic[], opts: MarkedOptions): string =>
   marked
-    .parser(
-      [{ type: 'paragraph', raw: '', tokens } as Tokens.Paragraph],
-      PARSER_OPTS,
-    )
+    .parser([{ type: 'paragraph', raw: '', tokens } as Tokens.Paragraph], opts)
     .replace(STRIP_P_RE, '');
 
 const buildItems = (
   listItems: Tokens.ListItem[],
   idPrefix: string,
+  opts: MarkedOptions,
 ): ChecklistItem[] =>
   listItems.map((item, index) => {
     const id = `${idPrefix}.${index}`;
@@ -70,12 +68,13 @@ const buildItems = (
           ...buildItems(
             (token as Tokens.List).items,
             `${id}.${NESTED_LIST_SUFFIX}`,
+            opts,
           ),
         );
       } else if (token.type === 'text') {
-        html += inlineHtml((token as Tokens.Text).tokens ?? []);
+        html += inlineHtml((token as Tokens.Text).tokens ?? [], opts);
       } else {
-        html += marked.parser([token], PARSER_OPTS);
+        html += marked.parser([token], opts);
       }
     }
     return { id, html, children };
@@ -83,6 +82,14 @@ const buildItems = (
 
 // Only top-level lists become checkboxes; everything else renders as normal markdown.
 const parseContent = (content: string): ContentBlock[] => {
+  // marked.parser()'s options replace marked.defaults entirely rather than merging with it,
+  // and a fresh renderer per call keeps heading-id dedup state isolated per parse (see
+  // markdown-config.ts's createHeadingRenderer for why that isolation matters).
+  const opts: MarkedOptions = {
+    ...marked.defaults,
+    renderer: createHeadingRenderer(),
+    async: false,
+  };
   const tokens = marked.lexer(content);
   let listIndex = 0;
 
@@ -91,10 +98,10 @@ const parseContent = (content: string): ContentBlock[] => {
       const idPrefix = `${LIST_ID_PREFIX}${listIndex++}`;
       return {
         kind: 'list',
-        items: buildItems((token as Tokens.List).items, idPrefix),
+        items: buildItems((token as Tokens.List).items, idPrefix, opts),
       };
     }
-    return { kind: 'html', html: marked.parser([token], PARSER_OPTS) };
+    return { kind: 'html', html: marked.parser([token], opts) };
   });
 };
 
@@ -195,6 +202,10 @@ export function ChecklistViewer({
     setChecked(loadChecked(filePath));
   }, [filePath]);
 
+  useEffect(() => {
+    scrollToUrlHash();
+  }, [blocks]);
+
   const toggle = (id: string) => {
     setChecked(prev => {
       const next = new Set(prev);
@@ -261,7 +272,9 @@ export function ChecklistViewer({
             <div
               key={index}
               className={CLS.BLOCK}
-              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(block.html) }}
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(block.html),
+              }}
             />
           ),
         )}

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/markdown-config.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/markdown-config.ts
@@ -1,0 +1,21 @@
+import { marked } from 'marked';
+import GithubSlugger from 'github-slugger';
+
+const HTML_TAG_RE = /<[!/a-z].*?>/gi;
+
+// A fresh renderer+slugger per parse call, not a shared/global one: marked's own
+// heading-id extensions track dedup state in shared module scope, which breaks
+// under React Strict Mode's double-invoked effects/memos (two overlapping parses
+// for the same content stomp on each other's reset) and under any real overlapping
+// parse (e.g. switching files before the previous parse settles).
+export const createHeadingRenderer = () => {
+  const slugger = new GithubSlugger();
+  const renderer = new marked.Renderer();
+  renderer.heading = (text: string, level: number, raw: string): string => {
+    const id = slugger.slug(raw.toLowerCase().trim().replace(HTML_TAG_RE, ''));
+    return `<h${level} id="${id}">${text}</h${level}>\n`;
+  };
+  return renderer;
+};
+
+export { marked };

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/markdown-config.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/markdown-config.ts
@@ -1,7 +1,6 @@
 import { marked } from 'marked';
 import GithubSlugger from 'github-slugger';
 
-const HTML_TAG_RE = /<[!/a-z].*?>/gi;
 const ATTR_ESCAPE_RE = /[&<>"]/g;
 const ATTR_ESCAPE_MAP: Record<string, string> = {
   '&': '&amp;',
@@ -10,10 +9,8 @@ const ATTR_ESCAPE_MAP: Record<string, string> = {
   '"': '&quot;',
 };
 
-// The tag-stripping regex above is only a slug-quality cleanup (drop inline HTML
-// remnants before slugifying), not a security control — it's not exhaustive, and
-// the slug library's own character filtering isn't something to rely on for that
-// either. Escape the id explicitly at the point it's embedded in the attribute.
+// Escape the id explicitly at the point it's embedded in the attribute, rather
+// than relying on the slug library's own character filtering as a security control.
 const escapeAttr = (value: string): string =>
   value.replace(ATTR_ESCAPE_RE, char => ATTR_ESCAPE_MAP[char]);
 
@@ -26,7 +23,7 @@ export const createHeadingRenderer = () => {
   const slugger = new GithubSlugger();
   const renderer = new marked.Renderer();
   renderer.heading = (text: string, level: number, raw: string): string => {
-    const id = slugger.slug(raw.toLowerCase().trim().replace(HTML_TAG_RE, ''));
+    const id = slugger.slug(raw.toLowerCase().trim());
     return `<h${level} id="${escapeAttr(id)}">${text}</h${level}>\n`;
   };
   return renderer;

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/markdown-config.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/markdown-config.ts
@@ -2,6 +2,20 @@ import { marked } from 'marked';
 import GithubSlugger from 'github-slugger';
 
 const HTML_TAG_RE = /<[!/a-z].*?>/gi;
+const ATTR_ESCAPE_RE = /[&<>"]/g;
+const ATTR_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+};
+
+// The tag-stripping regex above is only a slug-quality cleanup (drop inline HTML
+// remnants before slugifying), not a security control — it's not exhaustive, and
+// the slug library's own character filtering isn't something to rely on for that
+// either. Escape the id explicitly at the point it's embedded in the attribute.
+const escapeAttr = (value: string): string =>
+  value.replace(ATTR_ESCAPE_RE, char => ATTR_ESCAPE_MAP[char]);
 
 // A fresh renderer+slugger per parse call, not a shared/global one: marked's own
 // heading-id extensions track dedup state in shared module scope, which breaks
@@ -13,7 +27,7 @@ export const createHeadingRenderer = () => {
   const renderer = new marked.Renderer();
   renderer.heading = (text: string, level: number, raw: string): string => {
     const id = slugger.slug(raw.toLowerCase().trim().replace(HTML_TAG_RE, ''));
-    return `<h${level} id="${id}">${text}</h${level}>\n`;
+    return `<h${level} id="${escapeAttr(id)}">${text}</h${level}>\n`;
   };
   return renderer;
 };

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/markdown-viewer.tsx
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/markdown-viewer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { marked } from 'marked';
 import DOMPurify from 'dompurify';
-import { createNoteLinkClickHandler } from './note-links';
+import { createHeadingRenderer, marked } from './markdown-config';
+import { createNoteLinkClickHandler, scrollToUrlHash } from './note-links';
 
 const CLS = {
   ROOT: 'w-full h-full overflow-auto',
@@ -48,11 +48,17 @@ export function MarkdownViewer({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    marked.parse(content, { async: true }).then(raw => {
-      if (typeof window === 'undefined') return;
-      setHtml(DOMPurify.sanitize(raw));
-    });
+    marked
+      .parse(content, { renderer: createHeadingRenderer(), async: true })
+      .then(raw => {
+        if (typeof window === 'undefined') return;
+        setHtml(DOMPurify.sanitize(raw));
+      });
   }, [content]);
+
+  useEffect(() => {
+    if (html) scrollToUrlHash();
+  }, [html]);
 
   const canEdit = Boolean(saveContent && filePath);
 

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/note-links.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/note-links.ts
@@ -29,6 +29,14 @@ export const resolveNoteLink = (
   return resolved.join(PATH_SEP);
 };
 
+// The browser's native scroll-to-fragment only fires around the initial page load; by the
+// time async-fetched content renders its headings, that window has already closed.
+export const scrollToUrlHash = () => {
+  const hash = window.location.hash.slice(1);
+  if (!hash) return;
+  document.getElementById(hash)?.scrollIntoView();
+};
+
 export const createNoteLinkClickHandler =
   (filePath: string, onNavigate?: (path: string) => void) =>
   (event: MouseEvent<HTMLElement>) => {

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/note-links.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/note-links.ts
@@ -11,7 +11,7 @@ export const resolveNoteLink = (
 ): string | null => {
   if (!href || EXTERNAL_OR_HASH_HREF_RE.test(href)) return null;
 
-  const rawPath = href.split('#')[0];
+  const [rawPath, hash] = href.split('#');
   if (!rawPath) return null;
 
   const segments = [
@@ -26,7 +26,8 @@ export const resolveNoteLink = (
     else resolved.push(segment);
   }
 
-  return resolved.join(PATH_SEP);
+  const resolvedPath = resolved.join(PATH_SEP);
+  return hash ? `${resolvedPath}#${hash}` : resolvedPath;
 };
 
 // The browser's native scroll-to-fragment only fires around the initial page load; by the

--- a/projects/nx-workspace/package.json
+++ b/projects/nx-workspace/package.json
@@ -186,6 +186,7 @@
     "fastify-plugin": "^5.1.0",
     "fuse.js": "^7.4.2",
     "gapi-script": "^1.2.0",
+    "github-slugger": "^2.0.0",
     "googleapis": "^154.1.0",
     "isomorphic-dompurify": "^2.36.0",
     "json-schema-to-ts": "^3.1.1",

--- a/projects/nx-workspace/pnpm-lock.yaml
+++ b/projects/nx-workspace/pnpm-lock.yaml
@@ -193,6 +193,9 @@ importers:
       gapi-script:
         specifier: ^1.2.0
         version: 1.2.0
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       googleapis:
         specifier: ^154.1.0
         version: 154.1.0
@@ -337,7 +340,7 @@ importers:
         version: 21.3.1(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)
       '@angular/cli':
         specifier: 21.2.17
-        version: 21.2.17(@types/node@24.13.3)(chokidar@5.0.0)
+        version: 21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1)
       '@angular/compiler-cli':
         specifier: 21.2.17
         version: 21.2.17(@angular/compiler@21.2.17)(typescript@5.9.3)
@@ -517,7 +520,7 @@ importers:
         version: 8.20.0
       angular-eslint:
         specifier: ^21.4.0
-        version: 21.4.0(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript-eslint@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3)
+        version: 21.4.0(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript-eslint@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3)
       autoprefixer:
         specifier: 10.4.13
         version: 10.4.13(postcss@8.5.16)
@@ -20415,6 +20418,12 @@ packages:
         integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==,
       }
 
+  github-slugger@2.0.0:
+    resolution:
+      {
+        integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==,
+      }
+
   glob-parent@5.1.2:
     resolution:
       {
@@ -31793,11 +31802,11 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-eslint/builder@21.4.0(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)':
+  '@angular-eslint/builder@21.4.0(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)':
     dependencies:
       '@angular-devkit/architect': 0.2102.18(chokidar@5.0.0)
       '@angular-devkit/core': 21.2.5(chokidar@5.0.0)
-      '@angular/cli': 21.2.17(@types/node@24.13.3)(chokidar@5.0.0)
+      '@angular/cli': 21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1)
       eslint: 9.27.0(jiti@2.4.2)(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -31849,13 +31858,13 @@ snapshots:
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@angular-eslint/schematics@21.4.0(@angular-eslint/template-parser@21.4.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3))(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0))(@typescript-eslint/types@8.63.0)(@typescript-eslint/utils@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)':
+  '@angular-eslint/schematics@21.4.0(@angular-eslint/template-parser@21.4.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3))(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1))(@typescript-eslint/types@8.63.0)(@typescript-eslint/utils@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)':
     dependencies:
       '@angular-devkit/core': 21.2.5(chokidar@5.0.0)
       '@angular-devkit/schematics': 21.2.5(chokidar@5.0.0)
       '@angular-eslint/eslint-plugin': 21.4.0(@typescript-eslint/utils@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)
       '@angular-eslint/eslint-plugin-template': 21.4.0(@angular-eslint/template-parser@21.4.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3))(@typescript-eslint/types@8.63.0)(@typescript-eslint/utils@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)
-      '@angular/cli': 21.2.17(@types/node@24.13.3)(chokidar@5.0.0)
+      '@angular/cli': 21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1)
       ignore: 7.0.5
       semver: 7.7.4
       strip-json-comments: 3.1.1
@@ -32013,7 +32022,7 @@ snapshots:
       - yaml
     optional: true
 
-  '@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0)':
+  '@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1)':
     dependencies:
       '@angular-devkit/architect': 0.2102.17(chokidar@5.0.0)
       '@angular-devkit/core': 21.2.17(chokidar@5.0.0)
@@ -32028,7 +32037,7 @@ snapshots:
       jsonc-parser: 3.3.1
       listr2: 9.0.5
       npm-package-arg: 13.0.2
-      pacote: 21.5.1
+      pacote: 21.5.1(supports-color@8.1.1)
       parse5-html-rewriting-stream: 8.0.0
       semver: 7.7.4
       yargs: 18.0.0
@@ -40898,10 +40907,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@sigstore/tuf@4.0.2':
+  '@sigstore/tuf@4.0.2(supports-color@8.1.1)':
     dependencies:
       '@sigstore/protobuf-specs': 0.5.1
-      tuf-js: 4.1.0
+      tuf-js: 4.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -43382,16 +43391,16 @@ snapshots:
       buffer-more-ints: 1.0.0
       url-parse: 1.5.10
 
-  angular-eslint@21.4.0(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript-eslint@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3):
+  angular-eslint@21.4.0(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript-eslint@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
       '@angular-devkit/core': 21.2.5(chokidar@5.0.0)
       '@angular-devkit/schematics': 21.2.5(chokidar@5.0.0)
-      '@angular-eslint/builder': 21.4.0(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)
+      '@angular-eslint/builder': 21.4.0(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)
       '@angular-eslint/eslint-plugin': 21.4.0(@typescript-eslint/utils@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)
       '@angular-eslint/eslint-plugin-template': 21.4.0(@angular-eslint/template-parser@21.4.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3))(@typescript-eslint/types@8.63.0)(@typescript-eslint/utils@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)
-      '@angular-eslint/schematics': 21.4.0(@angular-eslint/template-parser@21.4.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3))(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0))(@typescript-eslint/types@8.63.0)(@typescript-eslint/utils@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)
+      '@angular-eslint/schematics': 21.4.0(@angular-eslint/template-parser@21.4.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3))(@angular/cli@21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1))(@typescript-eslint/types@8.63.0)(@typescript-eslint/utils@8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(chokidar@5.0.0)(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)
       '@angular-eslint/template-parser': 21.4.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(typescript@5.9.3)
-      '@angular/cli': 21.2.17(@types/node@24.13.3)(chokidar@5.0.0)
+      '@angular/cli': 21.2.17(@types/node@24.13.3)(chokidar@5.0.0)(supports-color@8.1.1)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/utils': 8.63.0(eslint@9.27.0(jiti@2.4.2)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       eslint: 9.27.0(jiti@2.4.2)(supports-color@8.1.1)
@@ -46830,6 +46839,8 @@ snapshots:
       assert-plus: 1.0.0
 
   github-from-package@0.0.0: {}
+
+  github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -50654,7 +50665,7 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  pacote@21.5.1:
+  pacote@21.5.1(supports-color@8.1.1):
     dependencies:
       '@gar/promise-retry': 1.0.3
       '@npmcli/git': 7.0.2
@@ -50670,7 +50681,7 @@ snapshots:
       npm-pick-manifest: 11.0.3
       npm-registry-fetch: 19.1.1
       proc-log: 6.1.0
-      sigstore: 4.1.1
+      sigstore: 4.1.1(supports-color@8.1.1)
       ssri: 13.0.1
       tar: 7.5.19
     transitivePeerDependencies:
@@ -52729,13 +52740,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sigstore@4.1.1:
+  sigstore@4.1.1(supports-color@8.1.1):
     dependencies:
       '@sigstore/bundle': 4.0.0
       '@sigstore/core': 3.2.1
       '@sigstore/protobuf-specs': 0.5.1
       '@sigstore/sign': 4.1.1
-      '@sigstore/tuf': 4.0.2
+      '@sigstore/tuf': 4.0.2(supports-color@8.1.1)
       '@sigstore/verify': 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -53795,7 +53806,7 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  tuf-js@4.1.0:
+  tuf-js@4.1.0(supports-color@8.1.1):
     dependencies:
       '@tufjs/models': 4.1.0
       debug: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
## Summary
- **Fix:** table-of-contents and cross-file anchor links (`[Section](#section)`) didn't scroll to their target heading. Three compounding causes, found by testing against the real app in a browser rather than trusting each fix in isolation:
  - `marked` v5+ no longer assigns heading `id`s by default — added a per-parse-call heading renderer (`markdown-config.ts`'s `createHeadingRenderer`, using `github-slugger`) instead of a shared/global one, since `marked`'s own heading-id extensions track dedup state in module scope and broke under React Strict Mode's double-invoked effects (confirmed live: every id was getting a spurious `-1` suffix).
  - Both apps' `urlSync.set()` silently stripped `window.location.hash` whenever the selected file synced back into the URL — including on initial page load, before any scrolling could even be attempted. Fixed to preserve the hash.
  - The browser's native scroll-to-fragment only fires around the initial page load, well before this SPA's async-fetched content (and its heading ids) exist in the DOM. Added `scrollToUrlHash()` (`note-links.ts`), called after content renders in both `MarkdownViewer` and `ChecklistViewer`.
- **Docs:** adds `libs/@vigilant-broccoli/react-lib/docs/features/docs-explorer.md`, documenting the `DocsExplorer`/`DocsViewer` markdown doc-browsing system end-to-end — exports, props, and non-obvious behaviors (this anchor-jump fix, the checklist-view content-fidelity fix from #191, and per-app search implementations from #190).

## Test plan
- [x] `nx lint`/`nx build` clean for `react-utility`, `docs-md`, `vb-manager-next`
- [x] Verified live in the browser against `outdoor-packlist.md`'s table of contents:
  - Direct URL load with `?file=...#essentials` now scrolls to the heading, in both Markdown and Checklist view
  - In-page TOC link clicks still work (native browser behavior, unaffected)
  - Heading ids match hand-authored anchors exactly, no dedup-suffix artifacts across file switches
- [x] Every claim in the updated feature doc cross-checked against current source

🤖 Generated with [Claude Code](https://claude.com/claude-code)