### PR TITLE
fix(smoke-dist): Pick a verified-free port instead of deriving one from PID

### DIFF
--- a/projects/nx-workspace/scripts/shell/smoke-dist.sh
+++ b/projects/nx-workspace/scripts/shell/smoke-dist.sh
@@ -18,9 +18,30 @@
 set -euo pipefail
 
 DIST_DIR="${1:?usage: smoke-dist.sh <dist-dir>}"
-PORT="${SMOKE_PORT:-$((30000 + ($$ % 20000)))}"
 TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-20}"
 HEALTH_PATH="${SMOKE_HEALTH_PATH:-/}"
+
+# A PID-derived port isn't collision-safe: it doesn't check the port is
+# actually free, and mod-reduction means unrelated processes started later
+# in the same job can land on the same value. Probe candidates instead.
+port_is_free() {
+  ! (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+}
+
+pick_free_port() {
+  local candidate attempt
+  for attempt in $(seq 1 20); do
+    candidate=$((30000 + RANDOM % 20000))
+    if port_is_free "$candidate"; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  echo "smoke-dist: could not find a free port after 20 attempts" >&2
+  return 1
+}
+
+PORT="${SMOKE_PORT:-$(pick_free_port)}"
 
 if [ ! -f "$DIST_DIR/main.js" ]; then
   echo "smoke-dist: $DIST_DIR/main.js not found"


### PR DESCRIPTION
## Summary
- `smoke-dist.sh` picked its smoke-test port via `$$ % 20000`, which never checks whether the port is actually free — it just hopes a hash of the shell's PID happens to be unused.
- This caused a real CI failure: `vb-express:smoke` crashed with `EADDRINUSE: address already in use 127.0.0.1:36730` in [run 30274275145](https://github.com/iamharryliu/vigilant-broccoli/actions/runs/30274275145/job/90004291158), which skipped `vb-express:deploy` for that run (all 16 other apps deployed fine).
- Replaced it with `pick_free_port`, which probes random candidate ports with a real TCP connect check (`/dev/tcp`) and retries up to 20 times until it finds one that's actually free.

## Test plan
- [x] `bash -n` syntax check on the updated script
- [x] Manually verified `port_is_free`/`pick_free_port` against a live listener: correctly detects the occupied port and returns a genuinely free one
- [ ] Confirm `vb-express:smoke` passes on the next `deploy-apps` CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)