### PR TITLE
feat(infrastructure): Add pnpm aws:login and test AWS EC2 provisioning

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -17,6 +17,7 @@ Useful infra-level CLI commands, runnable via `pnpm run <script>`.
   gcp:login                   Login to GCP and set project
   gh:login                    Login to GitHub CLI
   npm:login                   Login to npm
+  aws:login                   Login to AWS SSO (AdministratorAccess-841376026547)
   oracle:config               Edit OCI config
 
 🏗️  TERRAFORM

--- a/infrastructure/terraform/.terraform.lock.hcl
+++ b/infrastructure/terraform/.terraform.lock.hcl
@@ -18,6 +18,29 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "5.45.2"
   constraints = "~> 5.0"

--- a/infrastructure/terraform/aws.tf
+++ b/infrastructure/terraform/aws.tf
@@ -1,0 +1,23 @@
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "test" {
+  ami           = data.aws_ami.amazon_linux.id
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "vb-aws-test"
+  }
+}

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -27,6 +27,10 @@ terraform {
       source  = "oracle/oci"
       version = "~> 6.0"
     }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.0"
@@ -57,6 +61,11 @@ provider "cloudflare" {}
 provider "oci" {
   config_file_profile = "DEFAULT"
   region              = "ca-toronto-1"
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = "AdministratorAccess-841376026547"
 }
 
 # Reads SUPABASE_ACCESS_TOKEN from env (personal access token from

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -43,3 +43,7 @@ output "journal_url" {
 output "docs_url" {
   value = "https://${var.docs_domain}"
 }
+
+output "aws_test_instance_public_ip" {
+  value = aws_instance.test.public_ip
+}

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -8,6 +8,11 @@ variable "zone" {
   default = "us-central1-a"
 }
 
+variable "aws_region" {
+  type    = string
+  default = "eu-north-1"
+}
+
 variable "github_owner" {
   description = "GitHub repository owner"
   type        = string

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "format:commit": "prettier --write",
     "cloud:login": "pnpm gcp:login",
     "gcp:login": "gcloud auth login && gcloud config set project vigilant-broccoli && gcloud auth application-default login",
+    "aws:login": "aws sso login --profile AdministratorAccess-841376026547",
     "gh:login": "gh auth login && gh auth refresh -h github.com -s admin:org,delete_repo",
     "npm:login": "npm login",
     "oracle:config": "vim ~/.oci/config",


### PR DESCRIPTION
## Summary
- Adds `pnpm aws:login` (`aws sso login --profile AdministratorAccess-841376026547`), following the same pattern as `gcp:login`/`gh:login`; documented in the cheatsheet.
- Adds the `aws` provider to the shared Terraform Cloud workspace, authenticated via the same local SSO profile (mirrors how `provider "oci"` reads `~/.oci/config` locally instead of a Vault-injected token).
- Adds a minimal `aws_instance.test` (t3.micro, latest Amazon Linux 2023 AMI) in `infrastructure/terraform/aws.tf` as a smoke test to confirm the provider/auth wiring works end-to-end, plus its public IP as a Terraform output.
- `terraform init` / `terraform validate` both pass locally with the new provider locked in `.terraform.lock.hcl`.

## Test plan
- [ ] Run `pnpm aws:login` and confirm SSO login succeeds
- [ ] Run `pnpm tf:plan` and confirm the plan shows the new `aws_instance.test` resource cleanly (no errors, no unrelated diffs)
- [ ] Optionally `pnpm tf:apply` to provision the test instance, verify it appears in the AWS console under 841376026547, then decide whether to keep or tear it down

🤖 Generated with [Claude Code](https://claude.com/claude-code)