### PR TITLE
feat(bruno): Add AlexisHR, Cinode, and Slack request collections

### DIFF
--- a/bruno/.env.example
+++ b/bruno/.env.example
@@ -1,1 +1,15 @@
 RESEND_API_KEY=
+
+ALEXISHR_API_KEY=
+
+CINODE_ACCESS_ID=
+CINODE_ACCESS_SECRET=
+# Used to get access token {Base64Encoded(AccessId:AccessSecret)}
+CINODE_AUTH_TOKEN=
+# From Get Cinode Access and Refresh Tokens
+CINODE_ACCESS_TOKEN=
+COMPANY_ID=
+USER_ID=
+ABSENCE_ID=
+
+SLACKBOT_TOKEN=

--- a/bruno/AlexisHR/Delete Employee.bru
+++ b/bruno/AlexisHR/Delete Employee.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Delete Employee
+  type: http
+  seq: 6
+}
+
+delete {
+  url: https://api.alexishr.com/v1/employee/
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.ALEXISHR_API_KEY}}
+  Content-Type: application/json
+}

--- a/bruno/AlexisHR/Get Employees Filtered.bru
+++ b/bruno/AlexisHR/Get Employees Filtered.bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Employees Filtered
+  type: http
+  seq: 2
+}
+
+get {
+  url: https://api.alexishr.com/v1/employee?limit=500&select=workEmail
+  body: none
+  auth: none
+}
+
+params:query {
+  limit: 500
+  select: workEmail
+}
+
+headers {
+  Authorization: Bearer {{process.env.ALEXISHR_API_KEY}}
+}

--- a/bruno/AlexisHR/Get Employees Unfiltered.bru
+++ b/bruno/AlexisHR/Get Employees Unfiltered.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get Employees Unfiltered
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://api.alexishr.com/v1/employee?limit=500
+  body: none
+  auth: none
+}
+
+params:query {
+  limit: 500
+}
+
+headers {
+  Authorization: Bearer {{process.env.ALEXISHR_API_KEY}}
+}

--- a/bruno/AlexisHR/Get Leave Types.bru
+++ b/bruno/AlexisHR/Get Leave Types.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Leave Types
+  type: http
+  seq: 9
+}
+
+get {
+  url: https://api.alexishr.com/v1/leave-type
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.ALEXISHR_API_KEY}}
+}

--- a/bruno/AlexisHR/Get Leaves.bru
+++ b/bruno/AlexisHR/Get Leaves.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get Leaves
+  type: http
+  seq: 8
+}
+
+get {
+  url: https://api.alexishr.com/v1/leave?relations=type,employee
+  body: none
+  auth: none
+}
+
+params:query {
+  relations: type,employee
+}
+
+headers {
+  Authorization: Bearer {{process.env.ALEXISHR_API_KEY}}
+}

--- a/bruno/AlexisHR/Get Offices.bru
+++ b/bruno/AlexisHR/Get Offices.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get Offices
+  type: http
+  seq: 3
+}
+
+get {
+  url: https://api.alexishr.com/v1/office?select=id,name
+  body: none
+  auth: none
+}
+
+params:query {
+  select: id,name
+}
+
+headers {
+  Authorization: Bearer {{process.env.ALEXISHR_API_KEY}}
+}

--- a/bruno/AlexisHR/Get Teams.bru
+++ b/bruno/AlexisHR/Get Teams.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Get Teams
+  type: http
+  seq: 1
+}
+
+get {
+  url: https://api.alexishr.com/v1/team
+  body: none
+  auth: none
+}
+
+params:query {
+  ~select: SOME_ARRAY_VALUE
+  ~filters: SOME_OBJECT_VALUE
+  ~limit: SOME_INTEGER_VALUE
+  ~offset: SOME_INTEGER_VALUE
+  ~sort: SOME_OBJECT_VALUE
+}
+
+headers {
+  Authorization: Bearer {{process.env.ALEXISHR_API_KEY}}
+}

--- a/bruno/AlexisHR/Patch Employee.bru
+++ b/bruno/AlexisHR/Patch Employee.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Patch Employee
+  type: http
+  seq: 4
+}
+
+patch {
+  url: https://api.alexishr.com/v1/employee/66431809fd71c51926b9f612
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.ALEXISHR_API_KEY}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+      "title": "Consultant"
+  }
+}

--- a/bruno/AlexisHR/folder.bru
+++ b/bruno/AlexisHR/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: AlexisHR
+  seq: 2
+}
+
+auth {
+  mode: none
+}

--- a/bruno/Cinode/Create Absence.bru
+++ b/bruno/Cinode/Create Absence.bru
@@ -1,0 +1,25 @@
+meta {
+  name: Create Absence
+  type: http
+  seq: 10
+}
+
+post {
+  url: https://api.cinode.com/v0.1/companies/{{process.env.COMPANY_ID}}/users/{{process.env.USER_ID}}/absences
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.CINODE_ACCESS_TOKEN}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "start": "2026-07-02",
+    "end": "2026-07-09",
+    "extentPercentage": 100,
+    "absenceTypeId": 3088
+  }
+}

--- a/bruno/Cinode/Delete Absence.bru
+++ b/bruno/Cinode/Delete Absence.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Delete Absence
+  type: http
+  seq: 12
+}
+
+delete {
+  url: https://api.cinode.com/v0.1/companies/{{process.env.COMPANY_ID}}/users/{{process.env.USER_ID}}/absences/{{process.env.ABSENCE_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.CINODE_ACCESS_TOKEN}}
+}

--- a/bruno/Cinode/Get Absence Types.bru
+++ b/bruno/Cinode/Get Absence Types.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get Absence Types
+  type: http
+  seq: 9
+}
+
+get {
+  url: https://api.cinode.com/v0.1/companies/{{process.env.COMPANY_ID}}/absence/types
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.CINODE_ACCESS_TOKEN}}
+  Content-Type: application/json
+}

--- a/bruno/Cinode/Get Absences.bru
+++ b/bruno/Cinode/Get Absences.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get Absences
+  type: http
+  seq: 11
+}
+
+get {
+  url: https://api.cinode.com/v0.1/companies/{{process.env.COMPANY_ID}}/users/{{process.env.USER_ID}}/absences
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.CINODE_ACCESS_TOKEN}}
+  Content-Type: application/json
+}

--- a/bruno/Cinode/Get Availability (Access Token).bru
+++ b/bruno/Cinode/Get Availability (Access Token).bru
@@ -1,0 +1,20 @@
+meta {
+  name: Get Availability (Access Token)
+  type: http
+  seq: 7
+}
+
+post {
+  url: https://api.cinode.com/v0.1/companies/{{process.env.COMPANY_ID}}/availability
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.CINODE_ACCESS_TOKEN}}
+  Content-Type: application/json
+}
+
+body:json {
+  {}
+}

--- a/bruno/Cinode/Get Cinode Access and Refresh Tokens.bru
+++ b/bruno/Cinode/Get Cinode Access and Refresh Tokens.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get Cinode Access and Refresh Tokens
+  type: http
+  seq: 2
+}
+
+get {
+  url: https://api.cinode.com/token
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Basic {{process.env.CINODE_AUTH_TOKEN}}
+}

--- a/bruno/Cinode/Get Company (Access Token).bru
+++ b/bruno/Cinode/Get Company (Access Token).bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get Company (Access Token)
+  type: http
+  seq: 4
+}
+
+get {
+  url: https://api.cinode.com/v0.1/companies/{{process.env.COMPANY_ID}}/
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.CINODE_ACCESS_TOKEN}}
+  Content-Type: application/json
+}

--- a/bruno/Cinode/Get Company User (Access Token).bru
+++ b/bruno/Cinode/Get Company User (Access Token).bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get Company User (Access Token)
+  type: http
+  seq: 6
+}
+
+get {
+  url: https://api.cinode.com/v0.1/companies/{{process.env.COMPANY_ID}}/users/{{process.env.USER_ID}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.CINODE_ACCESS_TOKEN}}
+  Content-Type: application/json
+}

--- a/bruno/Cinode/Get Company Users (Access Token).bru
+++ b/bruno/Cinode/Get Company Users (Access Token).bru
@@ -1,0 +1,16 @@
+meta {
+  name: Get Company Users (Access Token)
+  type: http
+  seq: 5
+}
+
+get {
+  url: https://api.cinode.com/v0.1/companies/{{process.env.COMPANY_ID}}/users
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.CINODE_ACCESS_TOKEN}}
+  Content-Type: application/json
+}

--- a/bruno/Cinode/Patch User (Access Token).bru
+++ b/bruno/Cinode/Patch User (Access Token).bru
@@ -1,0 +1,20 @@
+meta {
+  name: Patch User (Access Token)
+  type: http
+  seq: 8
+}
+
+patch {
+  url: https://api.cinode.com/v0.1/companies/{{process.env.COMPANY_ID}}/users/{{process.env.USER_ID}}
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{process.env.CINODE_ACCESS_TOKEN}}
+  Content-Type: application/json
+}
+
+body:json {
+  [{"value":"2023-11-06T00:00:00.000000+00:00","path":"/employmentenddate","op":"replace"}]
+}

--- a/bruno/Cinode/Refresh Cinode Token (Access Token).bru
+++ b/bruno/Cinode/Refresh Cinode Token (Access Token).bru
@@ -1,0 +1,19 @@
+meta {
+  name: Refresh Cinode Token (Access Token)
+  type: http
+  seq: 3
+}
+
+post {
+  url: https://api.cinode.com/token/refresh
+  body: json
+  auth: none
+}
+
+headers {
+  Content-Type: application/json
+}
+
+body:json {
+  { "refreshToken": "REFRESH_TOKEN" }
+}

--- a/bruno/Cinode/folder.bru
+++ b/bruno/Cinode/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Cinode
+  seq: 3
+}
+
+auth {
+  mode: none
+}

--- a/bruno/Slack/View Publish.bru
+++ b/bruno/Slack/View Publish.bru
@@ -1,0 +1,43 @@
+meta {
+  name: View Publish
+  type: http
+  seq: 1
+}
+
+post {
+  url: https://slack.com/api/views.publish
+  body: json
+  auth: inherit
+}
+
+headers {
+  Authorization: Bearer {{process.env.SLACKBOT_TOKEN}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "user_id": "U08DG21SY8N",
+    "view": {
+      "type": "home",
+      "blocks": [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "This is a Block Kit example"
+          },
+          "accessory": {
+            "type": "image",
+            "image_url": "https://api.slack.com/img/blocks/bkb_template_images/notifications.png",
+            "alt_text": "calendar thumbnail"
+          }
+        }
+      ]
+    }
+  }
+}
+
+settings {
+  encodeUrl: true
+}

--- a/bruno/Slack/folder.bru
+++ b/bruno/Slack/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: Slack
+  seq: 4
+}
+
+auth {
+  mode: none
+}


### PR DESCRIPTION
## Summary
- Ports the AlexisHR, Cinode, and Slack request collections into this repo's `bruno/` workspace as folders (`bruno/AlexisHR`, `bruno/Cinode`, `bruno/Slack`), following the existing `bruno/resend` folder pattern (`folder.bru` with `meta`/`auth` instead of standalone `collection.bru`/`bruno.json`).
- Adds the required env var keys (blank placeholders) to `bruno/.env.example`: `ALEXISHR_API_KEY`, `CINODE_ACCESS_ID`, `CINODE_ACCESS_SECRET`, `CINODE_AUTH_TOKEN`, `CINODE_ACCESS_TOKEN`, `COMPANY_ID`, `USER_ID`, `ABSENCE_ID`, `SLACKBOT_TOKEN`.

## Test plan
- [ ] Open the `bruno/` collection in Bruno and confirm the AlexisHR, Cinode, and Slack folders load correctly
- [ ] Fill in real values for the new keys in a local `bruno/.env` and manually exercise a request from each new folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)