### PR TITLE
fix(ci-pr-check): Gate nx remote cache on token presence; run vault post-init on every tf:apply

### DIFF
--- a/.github/workflows/ci-pr-check.yml
+++ b/.github/workflows/ci-pr-check.yml
@@ -62,9 +62,22 @@ jobs:
         if: steps.check.outputs.nx-workspace-changed == 'true'
         working-directory: ./projects/nx-workspace
         env:
-          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: https://nx-cache.harryliu.dev
-          NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: ${{ env.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
-        run: pnpm exec nx affected -t lint test build --base=$NX_BASE --head=$NX_HEAD
+          # Enable the remote cache only when the token was actually fetched.
+          # Nx treats a configured-but-unreachable/unauthenticated cache as a
+          # fatal "Misconfigured remote cache endpoint" (the 401 fails the whole
+          # run), so setting the server URL with an empty token — e.g. when the
+          # Vault step above failed (continue-on-error), or before the role/token
+          # is provisioned — would break every PR. Leaving the server var UNSET
+          # makes Nx fall back to the local cache silently instead.
+          NX_CACHE_TOKEN: ${{ env.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
+        run: |
+          if [ -n "$NX_CACHE_TOKEN" ]; then
+            export NX_SELF_HOSTED_REMOTE_CACHE_SERVER=https://nx-cache.harryliu.dev
+            export NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN="$NX_CACHE_TOKEN"
+          else
+            echo "nx remote cache token unavailable — building with local cache only."
+          fi
+          pnpm exec nx affected -t lint test build --base=$NX_BASE --head=$NX_HEAD
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/TODO.md
+++ b/TODO.md
@@ -432,7 +432,24 @@ Separately, `search-dialog.component.tsx:23` and `quick-links.component.tsx:7` b
 
 ### Enhancements
 
-#### Local graph mode for the docs-md note viewer
+#### f7afb2. Provision Vault JWT policies/roles declaratively instead of the imperative post-init script
+
+**`infrastructure/terraform/scripts/post-apply.sh`, `infrastructure/terraform/packer/scripts/run-vault-post-init.sh`, `infrastructure/config.sh`, `package.json` (`gcp:vm:post-init`)**
+
+Vault's JWT auth config — the `github-actions-role` / `-rotate-role` / `-pr-check-role` roles and their policies — is currently written by the imperative `run-vault-post-init.sh`, which is really a VM-**bootstrap** script (it also runs `vault operator init`, enables the KV/JWT mounts, and seeds a `kv/test` placeholder). #217 made `post-apply.sh` call `npm run gcp:vm:post-init` on the IP-unchanged path so a new/edited role (e.g. `github-actions-pr-check-role`) is no longer silently skipped on a normal `tf:apply` — but that's an interim fix: it re-runs the whole heavy bootstrap script over IAP SSH on every apply, and policy/role definitions live as here-doc strings in a shell script rather than as reviewable declarative state.
+
+**Desired end state:** Vault policies/roles are managed as first-class Terraform resources (the `hashicorp/vault` provider's `vault_policy` + `vault_jwt_auth_backend_role`), so `tf:plan` shows role/policy diffs and `tf:apply` reconciles them like any other resource — no imperative re-run, no piggy-backing on VM bootstrap. `run-vault-post-init.sh` shrinks to genuine one-time bootstrap (init + mount enablement), and `post-apply.sh` no longer needs the interim unconditional `post-init` call.
+
+**Steps:**
+
+1. Add the `hashicorp/vault` provider to `infrastructure/terraform/main.tf` `required_providers`, configured to reach Vault over the same path local Terraform already uses (WireGuard `10.0.1.1:8200` + `NODE_EXTRA_CA_CERTS`/`VAULT_CACERT`); source the root token the way `load-vault-tf-env.sh` / `gcp-vault-token.ts` already do rather than a new secret. Confirm the CI path (`vault.harryliu.dev` tunnel) isn't broken — Terraform apply is local-only today, so this stays local.
+2. Port the two policies and three roles from `run-vault-post-init.sh` into `vault_policy` + `vault_jwt_auth_backend_role` resources, keeping the exact names/paths/TTLs/`bound_claims` (`job_workflow_ref` scoping for the rotate and pr-check roles) so nothing changes semantically. Reference `infrastructure/config.sh` values as Terraform vars/locals to keep one source of truth.
+3. `terraform import` the existing live policies/roles into the new resources so the first apply is a no-op diff, not a destroy/recreate.
+4. Strip the policy/role/`kv/test` blocks out of `run-vault-post-init.sh`, leaving only true bootstrap (init + KV/JWT mount enable). Remove the interim unconditional `npm run gcp:vm:post-init` call added to `post-apply.sh`'s IP-unchanged branch in #217.
+5. Update docs: [secret-management.md](./docs/infrastructure/secret-management.md) (the role/policy inventory now lives in Terraform) and any reference to `pnpm gcp:vm:post-init` being required after adding a Vault role.
+6. Verify: `pnpm tf:plan` shows the imported roles/policies as no-change, then edit one `bound_claims` and confirm `tf:plan` shows the diff and `tf:apply` reconciles it without touching the VM; confirm `ci-pr-check` and `ci-rotate-secrets` still authenticate to Vault afterward.
+
+#### faa345. Local graph mode for the docs-md note viewer
 
 **`libs/@vigilant-broccoli/react-utility/src/lib/graph-view.tsx`, `libs/@vigilant-broccoli/react-utility/src/lib/docs-viewer.tsx`, `libs/@vigilant-broccoli/react-lib/src/components/DocsExplorer.tsx`**
 

--- a/infrastructure/terraform/scripts/post-apply.sh
+++ b/infrastructure/terraform/scripts/post-apply.sh
@@ -269,6 +269,15 @@ sync_socket_server() {
 }
 
 if [ "$NEW_IP" = "$CURRENT_IP" ]; then
+  # Run post-init even when the VM IP is unchanged (the common case). It
+  # (re)writes Vault's JWT policies/roles, and it's idempotent — every
+  # `vault policy write` / `vault write auth/jwt/role/...` in
+  # run-vault-post-init.sh is an upsert. Without this, a Terraform/config
+  # change that adds or edits a Vault role (e.g. github-actions-pr-check-role)
+  # would be silently skipped on a normal `tf:apply`, since post-init only ran
+  # on the IP-changed branch below — leaving CI to fail with "role could not
+  # be found" until someone ran `pnpm gcp:vm:post-init` by hand.
+  npm run gcp:vm:post-init
   sync_secrets_to_vault
   sync_socket_server
   exit 0


### PR DESCRIPTION
## Summary

Two related fixes after #176 merged and `ci-pr-check` started **failing on real PRs** (e.g. run 30315066150) with:

```
NX  Misconfigured remote cache endpoint: Requests should respond with text/plain on 401s
```

— even though `lint`/`test`/`build` all succeeded first.

### 1. Gate the nx remote cache on token presence (`ci-pr-check.yml`)

Two things combined to fail the run:

- **Empty token.** The Vault step returned `role "github-actions-pr-check-role" could not be found` — the scoped Vault role wasn't provisioned on the live Vault (see fix #2). The step is `continue-on-error`, so the job continued with an **empty** `NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN`.
- **Nx makes cache errors fatal.** With the server URL still set but the token empty, Nx hit the cache unauthenticated, got a `401`, and treated it as a fatal "misconfigured endpoint" — exit 1 despite a green build. This is [nrwl/nx#36107](https://github.com/nrwl/nx/issues/36107): Nx treats *any* non-2xx cache response as fatal, even after tasks succeed, with no non-fatal flag. So `continue-on-error` on the Vault step alone can't save the run.

**Fix:** only export the cache env vars when the token is actually present; otherwise leave `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` unset so Nx silently uses the local cache. This also covers **fork PRs**, which never receive an OIDC token / secrets and so can never have a cache token.

### 2. Run vault post-init on every `tf:apply` (`post-apply.sh`)

Root cause of the empty token: `post-apply.sh` only ran `gcp:vm:post-init` (which writes Vault's JWT policies/roles) on the **VM-IP-changed** branch. Adding a new Vault role doesn't touch the VM, so on a normal `tf:apply` (IP unchanged) the new `github-actions-pr-check-role` was **silently skipped** — `tf:apply` synced the *tokens* but never created the *role* that lets CI read them.

**Fix:** run `gcp:vm:post-init` on the IP-unchanged path too, before the secret sync (mirroring the IP-changed path). `run-vault-post-init.sh` is idempotent — every `vault policy write` / `vault write auth/jwt/role/...` is an upsert — so this is safe to run on every apply, and future Vault role/policy changes will now land without a manual step.

`deploy.yml` is intentionally left untouched — it hasn't failed (it fetches the write token via the shared role from `kv/data/secrets`, synced by `tf:apply`'s post-apply). Its only latent risk is the write-token key being absent at deploy time; called out below rather than pre-emptively refactored.

## Provisioning (now a single step)

To actually get cache hits, run a successful `pnpm tf:apply`. With fix #2, that one command now:
1. Creates the Worker + tokens and syncs them to Vault (`NX_CACHE_WRITE_TOKEN` -> `kv/data/secrets`, `NX_CACHE_READ_TOKEN` -> `kv/data/ci-pr-check`), **and**
2. Runs post-init, creating `github-actions-pr-check-role` + policy on the live Vault (previously a separate manual `pnpm gcp:vm:post-init`).

Ensure `NX_CACHE_WRITE_TOKEN` is in `kv/data/secrets` before the next push-to-main deploy, or `deploy.yml`'s Vault step (which bundles it with `FLY_API_TOKEN` etc.) will hard-fail.

## Test plan

- [ ] Re-run `ci-pr-check` on a PR **before** provisioning: build succeeds, logs local-cache-only message, no fatal cache error.
- [ ] `pnpm tf:apply` on an IP-unchanged VM: post-init runs, `github-actions-pr-check-role` exists in Vault afterward (no manual `gcp:vm:post-init`).
- [ ] After apply: `ci-pr-check` fetches the read token and shows remote cache participation.
- [ ] Fork PR: build succeeds with local cache only (no token, no failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)