### PR TITLE
chore(resume): Remove the stale Resume quick-link pointing at the old Google Doc

### DIFF
--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/constants/quick-links.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/constants/quick-links.ts
@@ -1125,12 +1125,6 @@ const UTILITY_LINKS = [
 
 const CAREER_LINKS = [
   {
-    label: PERSONAL_URL.RESUME.NAME,
-    target: PERSONAL_URL.RESUME.URL,
-    type: OPEN_TYPE.BROWSER,
-    subgroup: LINK_GROUP_SUBGROUP.CAREER,
-  },
-  {
     label: 'LinkedIn',
     target: 'https://www.linkedin.com',
     type: OPEN_TYPE.BROWSER,

--- a/projects/nx-workspace/libs/@vigilant-broccoli/personal-common-js/src/index.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/personal-common-js/src/index.ts
@@ -32,10 +32,6 @@ export const VB_REPO_PATH = {
 } as const;
 
 export const PERSONAL_URL = {
-  RESUME: {
-    NAME: 'Resume',
-    URL: 'https://docs.google.com/document/d/1s6Wy8i4zU85o19qyXKhdpH4jdTP36QDPUgZdV7E6-QU/edit#heading=h.uzt44hq0695d',
-  },
   TO_DRAW: {
     NAME: 'To Draw',
     URL: 'https://ca.pinterest.com/prettydamntired/to-draw/',


### PR DESCRIPTION
## Summary
- Follow-up to #222 (resume moved from Google Docs to repo-generated).
- Found while auditing the old Drive-based resume implementation for leftovers: `PERSONAL_URL.RESUME` in `@vigilant-broccoli/personal-common-js` still pointed at the deprecated Google Doc, surfaced as a "Resume" quick-link in vb-manager-next's search dialog.
- That link is now stale (editing the Google Doc no longer affects the deployed resume) and redundant — the dashboard already auto-generates an internal "Career" quick-link for `/career` via `APP_ROUTE_QUICK_LINKS`.
- Removed the `RESUME` entry from `PERSONAL_URL` and the corresponding entry from `CAREER_LINKS` (which now just has LinkedIn).
- Checked Terraform and remaining scripts for other leftovers from the old Google Drive pipeline (service accounts, IAM bindings, API enablement, `googleapis` usage) — nothing else found; the WIF service account used by the removed cron was the generic repo-wide one, not resume-specific.

## Test plan
- [x] `tsc --noEmit` clean for `vb-manager-next`
- [x] `nx lint` clean for `vb-manager-next` and `@vigilant-broccoli/personal-common-js`
- [x] Grepped repo-wide for `PERSONAL_URL.RESUME` — no remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)