### PR TITLE
fix(agent-sandbox): Stage working tree before checkout in update-pr-runner

### DIFF
--- a/infrastructure/agent-sandbox/update-pr-runner.sh
+++ b/infrastructure/agent-sandbox/update-pr-runner.sh
@@ -44,6 +44,12 @@ EOF
 claude -p "$PROMPT" --dangerously-skip-permissions --model "$MODEL" \
   --disallowedTools "Bash(git commit:*)" "Bash(git push:*)" "Bash(git checkout:*)" "Bash(git switch:*)" "Bash(gh:*)"
 
+# Stage first: if the instruction involved resolving a merge conflict, the working
+# tree may hold a fix for it that was never `git add`-ed (the model is disallowed
+# from `git commit`, so it has no reason to stage). An unmerged index blocks the
+# checkout below even onto the branch we're already on, so clear that first.
+git add -A
+
 git checkout "$BRANCH"
 [ "$(git rev-parse HEAD)" = "$BASE_SHA" ] || git reset --soft "$BASE_SHA"
 


### PR DESCRIPTION
## Summary
- `pnpm agentic:pr:update 116 "Handle merge conflicts with main"` failed: the inner agent resolved the `TODO.md` conflict in the working tree but never `git add`-ed it (it's disallowed from `git commit`, so it had no reason to stage), leaving unmerged index entries.
- The runner's next step, `git checkout "$BRANCH"` (onto the branch already checked out), refused with `error: you need to resolve your current index first` / `TODO.md: needs merge`, and `set -euo pipefail` killed the script before the final commit/push — silently discarding the fix since the container runs with `--rm`.
- Fix: run `git add -A` right after the inner agent finishes and before that checkout, so any conflict resolution left in the working tree is staged first. This also lets the later `git commit` produce a real two-parent merge commit, since `MERGE_HEAD` is preserved rather than fought.

## Test plan
- [ ] Re-run `pnpm agentic:pr:update 116 "Handle merge conflicts with main"` and confirm the conflict resolution is committed and pushed to PR #116 instead of silently dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)