### PR TITLE
fix(dotfiles): Add missing base editor options and migrate nvim-trees…

### DIFF
--- a/setup/dotfiles/.config/nvim/init.lua
+++ b/setup/dotfiles/.config/nvim/init.lua
@@ -35,6 +35,20 @@ end
 vim.opt.clipboard = "unnamedplus"
 vim.opt.mouse = "a"
 
+vim.opt.number = true
+vim.opt.relativenumber = true
+vim.opt.signcolumn = "yes"
+
+vim.opt.tabstop = 2
+vim.opt.shiftwidth = 2
+vim.opt.expandtab = true
+
+vim.opt.ignorecase = true
+vim.opt.smartcase = true
+
+vim.opt.undofile = true
+vim.opt.scrolloff = 8
+
 vim.api.nvim_create_autocmd("TermOpen", {
   callback = function()
     vim.opt_local.number = false

--- a/setup/dotfiles/.config/nvim/lua/plugins/treesitter.lua
+++ b/setup/dotfiles/.config/nvim/lua/plugins/treesitter.lua
@@ -1,42 +1,58 @@
 return {
   {
     "nvim-treesitter/nvim-treesitter",
+    branch = "main",
+    lazy = false,
     build = ":TSUpdate",
     config = function()
-      require("nvim-treesitter.configs").setup({
-        ensure_installed = {
-          "typescript",
-          "tsx",
-          "javascript",
-          "lua",
-          "python",
-          "bash",
-          "json",
-          "yaml",
-          "hcl",
-          "terraform",
-          "markdown",
-          "markdown_inline",
-          "vim",
-          "vimdoc",
-          "query",
-        },
-        auto_install = true,
-        highlight = {
-          enable = true,
-        },
-        indent = {
-          enable = true,
-        },
-        incremental_selection = {
-          enable = true,
-          keymaps = {
-            init_selection = "<C-space>",
-            node_incremental = "<C-space>",
-            scope_incremental = false,
-            node_decremental = "<BS>",
-          },
-        },
+      local parsers = {
+        "typescript",
+        "tsx",
+        "javascript",
+        "lua",
+        "python",
+        "bash",
+        "json",
+        "yaml",
+        "hcl",
+        "terraform",
+        "markdown",
+        "markdown_inline",
+        "vim",
+        "vimdoc",
+        "query",
+      }
+      require("nvim-treesitter").install(parsers)
+
+      local function try_attach(buf, language)
+        if not vim.treesitter.language.add(language) then
+          return
+        end
+        vim.treesitter.start(buf, language)
+        if vim.treesitter.query.get(language, "indents") then
+          vim.bo[buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+        end
+      end
+
+      local available = require("nvim-treesitter").get_available()
+      vim.api.nvim_create_autocmd("FileType", {
+        callback = function(args)
+          local language = vim.treesitter.language.get_lang(args.match)
+          if not language then
+            return
+          end
+
+          local installed = require("nvim-treesitter").get_installed("parsers")
+          if vim.tbl_contains(installed, language) then
+            try_attach(args.buf, language)
+          elseif vim.tbl_contains(available, language) then
+            require("nvim-treesitter").install(language):await(function()
+              try_attach(args.buf, language)
+            end)
+          else
+            try_attach(args.buf, language)
+          end
+        end,
       })
     end,
   },


### PR DESCRIPTION
…itter to its new main-branch API.

The TermOpen autocmd turned number/relativenumber off for terminal buffers with nothing ever turning them on elsewhere, and nvim-treesitter's default branch moved to a rewritten main with no configs module, breaking plugin load.