### PR TITLE
fix(journal): Restore --skip-nx-cache for journal:deploy

### DIFF
--- a/.github/workflows/cron-deploy-journal.yml
+++ b/.github/workflows/cron-deploy-journal.yml
@@ -42,7 +42,6 @@ jobs:
             kv/data/secrets GITEA_TOKEN | GITEA_TOKEN ;
             kv/data/secrets GITEA_CF_ACCESS_CLIENT_ID | GITEA_CF_ACCESS_CLIENT_ID ;
             kv/data/secrets GITEA_CF_ACCESS_CLIENT_SECRET | GITEA_CF_ACCESS_CLIENT_SECRET ;
-            kv/data/secrets NX_CACHE_WRITE_TOKEN | NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN ;
 
       - name: Fetch journal notes from Gitea
         env:
@@ -72,6 +71,4 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ env.CLOUDFLARE_API_TOKEN }}
-          NX_SELF_HOSTED_REMOTE_CACHE_SERVER: https://nx-cache.harryliu.dev
-          NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN: ${{ env.NX_SELF_HOSTED_REMOTE_CACHE_ACCESS_TOKEN }}
-        run: pnpm exec nx run journal:deploy
+        run: pnpm exec nx run journal:deploy --skip-nx-cache


### PR DESCRIPTION
## Summary
- `journal.harryliu.dev` was throwing `Unexpected token '<', "<!doctype "... is not valid JSON` on load — the client fetches `structure.json` at runtime, and Cloudflare Pages' SPA fallback was serving `index.html` for it because that file was never actually in the deployed output.
- Root cause: PR #230 wired `journal:deploy` into the shared Nx remote cache. `journal:build`'s cache key hashes git-tracked inputs only, but `apps/ui/journal/public/structure.json` and `public/notes/**` are gitignored and regenerated from a live Gitea fetch on every hourly cron run — invisible to that hash. Every run since then computed an identical cache key and Nx replayed the same stale cached build (missing the notes content) instead of rebuilding.
- Confirmed via CI history: every `cron-deploy-journal` run through 2026-07-28 20:16 UTC uploaded `64/64` files (correct); the run immediately after PR #230 merged (21:43 UTC) dropped to `4/4` and stayed there through every run since.
- Fix: revert `journal:deploy` to `--skip-nx-cache` (this task's correctness depends on externally-fetched content the cache can't see) and drop the now-unused remote-cache secret/env wiring for this workflow. `component-library`/`pages-index`, the other targets PR #230 touched, keep caching since they only redeploy on real source changes.

## Test plan
- [x] Ran `nx run journal:build --skip-nx-cache` locally with fresh `structure.json`/`notes/**` staged in `public/` and confirmed both land correctly in `dist/apps/ui/journal` (matches the pre-regression, working behavior).
- [ ] Watch the next scheduled `cron-deploy-journal` run and confirm `wrangler pages deploy` reports the full file count (not `4/4`) and `journal.harryliu.dev/structure.json` returns real JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)