### PR TITLE
docs(claude): Add brevity guidance to coding conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@
 - Avoid string literals, prefer having consts.
 - Do not write tests unless explicitly asked.
 - Do not write markdown reports, summaries, or documentation unless explicitly asked.
+- Keep responses brief and concise — one sentence per update, no unnecessary narration.
 - If a PR touches files for a cloud service, or introduces/changes usage of one, add or update a `## Free Tier` section in that service's notes/docs file documenting its free tier limits (e.g. [github-actions.md](./notes/tech/software/web-dev/devops/automation/github-actions.md)).
 
 ## Folder Structure


### PR DESCRIPTION
## Summary
- Add explicit guidance to keep responses brief and concise (one sentence per update)
- Aligned with project's preference for terse, focused communication

## Test plan
- [ ] Verify the new line appears in CLAUDE.md
- [ ] Confirm no merge conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)