### PR TITLE
feat(vb-manager-next): Add split-view resume editor to career page

### DIFF
--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/api/resume/route.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/api/resume/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { writeFile } from 'fs/promises';
+import { join } from 'path';
+import { homedir } from 'os';
+import { HTTP_STATUS_CODES } from '@vigilant-broccoli/common-js';
+
+const RESUME_JSON_PATH = join(
+  homedir(),
+  'vigilant-broccoli',
+  'projects',
+  'nx-workspace',
+  'libs',
+  '@vigilant-broccoli',
+  'resume',
+  'src',
+  'resume.json',
+);
+const ENCODING = 'utf-8';
+
+const ERROR = {
+  CONTENT_REQUIRED: 'Resume JSON content is required',
+  INVALID_JSON: 'Resume content is not valid JSON',
+  SAVE_FAILED: 'Failed to save resume.json',
+} as const;
+
+export async function PUT(req: NextRequest) {
+  try {
+    const body = await req.json();
+    if (typeof body?.content !== 'string') {
+      return NextResponse.json(
+        { error: ERROR.CONTENT_REQUIRED },
+        { status: HTTP_STATUS_CODES.BAD_REQUEST },
+      );
+    }
+
+    try {
+      JSON.parse(body.content);
+    } catch {
+      return NextResponse.json(
+        { error: ERROR.INVALID_JSON },
+        { status: HTTP_STATUS_CODES.BAD_REQUEST },
+      );
+    }
+
+    await writeFile(RESUME_JSON_PATH, body.content, ENCODING);
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error(ERROR.SAVE_FAILED, error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : ERROR.SAVE_FAILED },
+      { status: HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR },
+    );
+  }
+}

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/pages/CareerPage.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/pages/CareerPage.tsx
@@ -1,13 +1,68 @@
 'use client';
 
-import { Button } from '@vigilant-broccoli/react-lib';
+import { useEffect, useState } from 'react';
+import { Button, Textarea } from '@vigilant-broccoli/react-lib';
+import { toast } from '@vigilant-broccoli/react-lib/toaster';
+import { Tabs } from '@radix-ui/themes';
 import { DownloadIcon } from '@radix-ui/react-icons';
 import { ResumeViewComponent } from '../resume-view.component';
-import { resumeData } from '@vigilant-broccoli/resume';
+import { resumeData, ResumeData } from '@vigilant-broccoli/resume';
+import { authFetch } from '../../../../libs/auth';
+
+const EDITOR_TAB = {
+  JSON: 'json',
+  AI: 'ai',
+} as const;
+
+type EditorTab = (typeof EDITOR_TAB)[keyof typeof EDITOR_TAB];
+
+const INITIAL_JSON_TEXT = JSON.stringify(resumeData, null, 2);
+
+const RESUME_API_PATH = '/api/resume';
+const SAVE_DEBOUNCE_MS = 500;
+
+const TOAST_MESSAGE = {
+  FAILED: 'Failed to save resume.json',
+} as const;
+
+const DEFAULT_JSON_ERROR = 'Invalid JSON';
 
 export const CareerPage = () => {
+  const [activeTab, setActiveTab] = useState<EditorTab>(EDITOR_TAB.JSON);
+  const [jsonText, setJsonText] = useState(INITIAL_JSON_TEXT);
+  const [resume, setResume] = useState<ResumeData>(resumeData);
+  const [jsonError, setJsonError] = useState<string | null>(null);
+
+  const handleJsonChange = (value: string) => {
+    setJsonText(value);
+    try {
+      setResume(JSON.parse(value) as ResumeData);
+      setJsonError(null);
+    } catch (error) {
+      setJsonError(error instanceof Error ? error.message : DEFAULT_JSON_ERROR);
+    }
+  };
+
+  useEffect(() => {
+    if (jsonError) return;
+
+    const timeoutId = setTimeout(() => {
+      authFetch(RESUME_API_PATH, {
+        method: 'PUT',
+        body: JSON.stringify({ content: jsonText }),
+      }).then(
+        response => {
+          if (!response.ok) toast.error(TOAST_MESSAGE.FAILED);
+        },
+        () => toast.error(TOAST_MESSAGE.FAILED),
+      );
+    }, SAVE_DEBOUNCE_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, [jsonText, jsonError]);
+
   return (
-    <div className="max-w-[850px] mx-auto print:max-w-none">
+    <div className="flex flex-col h-full print:block">
       <div className="print:hidden flex justify-end mb-3">
         <div className="text-right">
           <Button onClick={() => window.print()}>
@@ -19,7 +74,46 @@ export const CareerPage = () => {
           </p>
         </div>
       </div>
-      <ResumeViewComponent resume={resumeData} />
+
+      <div className="flex flex-1 min-h-0 print:block">
+        <div className="flex-1 min-w-0 print:hidden">
+          <Tabs.Root
+            value={activeTab}
+            onValueChange={value => setActiveTab(value as EditorTab)}
+            className="h-full flex flex-col"
+          >
+            <Tabs.List>
+              <Tabs.Trigger value={EDITOR_TAB.JSON}>Edit JSON</Tabs.Trigger>
+              <Tabs.Trigger value={EDITOR_TAB.AI}>AI Chat</Tabs.Trigger>
+            </Tabs.List>
+
+            <Tabs.Content
+              value={EDITOR_TAB.JSON}
+              className="pt-3 flex-1 min-h-0 flex flex-col"
+            >
+              <Textarea
+                value={jsonText}
+                onChange={event => handleJsonChange(event.target.value)}
+                spellCheck={false}
+                className="flex-1 min-h-0 font-mono text-xs resize-none"
+              />
+              {jsonError && (
+                <p className="text-xs text-red-600 mt-1">{jsonError}</p>
+              )}
+            </Tabs.Content>
+
+            <Tabs.Content value={EDITOR_TAB.AI} className="pt-3 flex-1 min-h-0">
+              <p className="text-sm text-muted-foreground">
+                AI chat editing is coming soon.
+              </p>
+            </Tabs.Content>
+          </Tabs.Root>
+        </div>
+
+        <div className="shrink-0 overflow-y-auto print:overflow-visible print:w-full">
+          <ResumeViewComponent resume={resume} />
+        </div>
+      </div>
     </div>
   );
 };

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/resume-view.component.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/resume-view.component.tsx
@@ -55,7 +55,7 @@ export const ResumeViewComponent = ({ resume }: { resume: ResumeData }) => {
 
   return (
     <div
-      className={`bg-white text-black text-[13px] leading-snug p-8 shadow-md print:shadow-none print:p-0 max-w-[850px] mx-auto print:max-w-none print:w-full ${roboto.className}`}
+      className={`bg-white text-black text-[13px] leading-snug p-8 shadow-md print:shadow-none print:p-0 max-w-[850px] print:max-w-none print:w-full ${roboto.className}`}
     >
       <div className="grid grid-cols-3 items-start mb-2">
         <div className="flex flex-col gap-0.5">

--- a/projects/nx-workspace/libs/@vigilant-broccoli/resume/src/resume.json
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/resume/src/resume.json
@@ -9,7 +9,10 @@
         "label": "linkedin.com/in/iamharryliu",
         "url": "https://linkedin.com/in/iamharryliu"
       },
-      { "label": "harryliu.dev", "url": "https://harryliu.dev" },
+      {
+        "label": "harryliu.dev",
+        "url": "https://harryliu.dev"
+      },
       {
         "label": "github.com/iamharryliu",
         "url": "https://github.com/iamharryliu"


### PR DESCRIPTION
## Summary
- Replaced the read-only `/career` resume view with a split-view layout: a live JSON editor on the left, the rendered resume preview flush to the right.
- The JSON tab auto-saves (debounced) straight to `libs/@vigilant-broccoli/resume/src/resume.json` via a new `/api/resume` PUT route, authenticated through the app's existing `authFetch` helper.
- Added a second "AI Chat" tab as an inert placeholder for a future AI-assisted editing flow — no wiring yet.
- Confirmed this doesn't affect the `personal-website-react` resume PDF: that build uses a fully separate Playwright/HTML render path (`libs/@vigilant-broccoli/resume/src/server.ts`), not the React `ResumeViewComponent` touched here.

## Test plan
- [x] `tsc --noEmit` on `vb-manager-next` passes with no errors.
- [x] `nx lint vb-manager-next` passes with no new warnings/errors on the changed files.
- [x] Manually exercised `/career` in a running dev server: split view renders, JSON edits live-update the preview, invalid JSON surfaces an inline error without crashing, and a valid autosave successfully PUTs to `/api/resume`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)