### PR TITLE
fix(react-lib): copy package.json into dist for publish-package

### DIFF
--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/vite.config.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/vite.config.ts
@@ -13,7 +13,13 @@ export default defineConfig({
   plugins: [
     react(),
     tsconfigPaths(),
-    viteStaticCopy({ targets: [{ src: '*.md', dest: '.' }], silent: true }),
+    viteStaticCopy({
+      targets: [
+        { src: '*.md', dest: '.' },
+        { src: 'package.json', dest: '.' },
+      ],
+      silent: true,
+    }),
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),


### PR DESCRIPTION
## Summary
- `react-lib`'s Vite build only copied `*.md` into `dist/`, so `publish-package`'s `resolve-workspace-deps.js` (which reads `dist/.../package.json`) always crashed with `ENOENT`.
- Added `package.json` to the existing `viteStaticCopy` targets in `vite.config.ts` so it lands in `dist/libs/@vigilant-broccoli/react-lib/` alongside the build output, matching how other publishable libs (`@nx/js:tsc`/`swc` with a `packageJson` option) already work.

## Test plan
- [x] `nx build react-lib` locally — confirmed `dist/libs/@vigilant-broccoli/react-lib/package.json` is now present
- [ ] Next `deploy-npm-packages` run publishes `react-lib` without the ENOENT failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)