### PR TITLE
fix(github-actions): Redeploy production after secret rotation, not just staging.

### DIFF
--- a/.github/workflows/ci-rotate-secrets.yml
+++ b/.github/workflows/ci-rotate-secrets.yml
@@ -121,7 +121,16 @@ jobs:
           CF_ACCESS_CLIENT_SECRET: ${{ steps.cf-access.outputs.CF_ACCESS_CLIENT_SECRET }}
         run: ./infrastructure/terraform/packer/scripts/rotate-twilio-token.sh
 
-  deploy:
+  deploy-staging:
     needs: rotate
     uses: ./.github/workflows/deploy.yml
+    with:
+      environment: staging
+    secrets: inherit
+
+  deploy-production:
+    needs: deploy-staging
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: production
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ on:
           - staging
           - production
   workflow_call:
+    inputs:
+      environment:
+        description: 'Deployment environment'
+        type: string
 
 permissions:
   actions: read

--- a/docs/infrastructure/secret-management.md
+++ b/docs/infrastructure/secret-management.md
@@ -7,7 +7,7 @@
 - Tooling generates them from the secret manager at run time instead:
   - Agent sandbox: `load-env-from-vault.sh` fetches Vault tokens and `export`s them straight into the current shell session — sourced (`. load-env-from-vault.sh`) or `eval "$(load-env-from-vault.sh)"` — never writing them to disk.
   - Terraform CLI env comes from `infrastructure/terraform/scripts/load-vault-tf-env.sh`.
-  - Local scripts read the Vault token via `projects/nx-workspace/scripts/gcp-vault-token.ts`.
+  - Local scripts read the Vault token via `projects/nx-workspace/scripts/gcp-vault-token.ts`, with `NODE_EXTRA_CA_CERTS=./scripts/vault-ca.crt` for Vault's self-signed cert.
 - Committed `*.env.example` files are fine — they list keys with no values and drive `deploy-flyio-secrets.ts`.
 - Non-secret identifiers (account IDs, zone IDs, GitHub App IDs, domains) are not secrets: hardcode them as variable `default`s in `infrastructure/terraform/variables.tf` (e.g. `upptime_gh_app_id`, `cloudflare_account_id`, `cloudflare_zone_id`) rather than routing them through `.tfvars` or Vault. Only the matching secret half — a private key or token — goes to the secret manager.
 
@@ -52,7 +52,7 @@ Rotate credentials semi-annually. Everything below Tier 0 lives in Vault at `kv/
 Entry points:
 
 - `pnpm secret-rotation:all` — single command: runs the local-only rotators in sequence (`secret-rotation:flyio`, `secret-rotation:gitea`, `secret-rotation:profile-deploy-key`), then dispatches the `rotate-secrets` workflow. `secret-rotation:rabbitmq`, `secret-rotation:resend`, and `secret-rotation:twilio` are deliberately excluded — the workflow already rotates all three, and their local modes use gcloud/IAP rather than the CI tunnel (see the table below).
-- `rotate-secrets` workflow (`ci-rotate-secrets.yml`) — verifies `FLY_API_TOKEN` from Vault (fails fast before rotating anything), regenerates `SHARED_APP_TOKEN` / `VB_EXPRESS_API_KEY`, syncs the new `SHARED_APP_TOKEN` to the socket-server VM as `SENDER_TOKEN`, rotates `RESEND_API_KEY`, `RABBITMQ_CONNECTION_STRING`, and `TWILIO_AUTH_TOKEN`, and redeploys.
+- `rotate-secrets` workflow (`ci-rotate-secrets.yml`) — verifies `FLY_API_TOKEN` from Vault (fails fast before rotating anything), regenerates `SHARED_APP_TOKEN` / `VB_EXPRESS_API_KEY`, syncs the new `SHARED_APP_TOKEN` to the socket-server VM as `SENDER_TOKEN`, rotates `RESEND_API_KEY`, `RABBITMQ_CONNECTION_STRING`, and `TWILIO_AUTH_TOKEN`, then calls `deploy.yml` twice — staging, then production — so both environments pick up the rotated values in the same run.
 
 Every rotator follows mint → verify → store → revoke, so Vault never holds a dead credential:
 

--- a/docs/repo-operations.md
+++ b/docs/repo-operations.md
@@ -16,12 +16,7 @@ Architecture diagrams: [infrastructure.md](./infrastructure/infrastructure.md).
 
 ## Secret Lifecycle
 
-Authority: [secret-management.md](./infrastructure/secret-management.md) — hierarchy, full key inventory, rotation procedures. Working summary:
-
-- Chain: Google account > GCP Secret Manager (Tier 0) > Vault (`kv/data/secrets`, on the GCP VM) > deploy secrets > app secrets — per-tier key inventory in secret-management.md.
-- **CI access**: Vault at `https://vault.harryliu.dev` (cloudflared tunnel, Cloudflare Access service token) + GitHub OIDC JWT auth, via `.github/actions/vault-secrets`. That action authenticates to GCP via Workload Identity Federation and pulls the Cloudflare Access token from Secret Manager, so the only plain GitHub secrets are `GCP_WORKLOAD_IDENTITY_PROVIDER` / `GCP_SERVICE_ACCOUNT` (the WIF bootstrap).
-- **Local access**: scripts fetch the Vault token from Secret Manager (`scripts/gcp-vault-token.ts`) with `NODE_EXTRA_CA_CERTS=./scripts/vault-ca.crt`.
-- **Rotation**: `pnpm secret-rotation:all` — runs the scripted rotations locally (Fly token — needs a `fly` user session; Gitea CI token; profile-repo deploy key) then dispatches the `rotate-secrets` workflow, which verifies `FLY_API_TOKEN`, regenerates `SHARED_APP_TOKEN` / `VB_EXPRESS_API_KEY`, and redeploys; the rest is manual rotate-at-source then `vault kv patch`. The rotate scripts push live secrets to the `staging-*` fly apps only — production apps pick up rotated values on their next `deploy:production` (extend the scripts' app lists once production is live).
+All of it — hierarchy, per-tier key inventory, CI and local Vault access, rotation commands and per-key mechanisms — lives in [secret-management.md](./infrastructure/secret-management.md). Read it before touching a secret.
 
 ## Data & Persistence Map
 


### PR DESCRIPTION
## Summary

- `deploy.yml` declared a bare `workflow_call:` with no inputs, so `inputs.environment` was empty in the called run and `DEPLOY_ENVIRONMENT` fell through to `github.ref_name == 'production' && 'production' || 'staging'`. Dispatched from `main`, that resolved to **staging** — production apps kept running credentials the rotation had already revoked, until someone manually ran a production deploy.
- Added an `environment` input to `deploy.yml`'s `workflow_call`. Deliberately **no `default`**, so any caller omitting it still hits the existing `ref_name` fallback and nothing else's behavior shifts.
- Split `ci-rotate-secrets.yml`'s `deploy` job into `deploy-staging` then `deploy-production`, chained via `needs:` rather than a matrix — the workflow-level `concurrency: deploy-${{ github.ref }}` with `cancel-in-progress: false` would serialize parallel calls anyway, and staging-first is the safer order.
- Docs: recorded the two-environment deploy in `secret-management.md` (the doc `repo-operations.md` already names as authority for rotation procedures), and collapsed the `Secret Lifecycle` section of `repo-operations.md` — which restated five facts already covered there — down to a pointer. The one fact not already in `secret-management.md` (`NODE_EXTRA_CA_CERTS=./scripts/vault-ca.crt` paired with `gcp-vault-token.ts`) was folded in before removal.

Two known side effects of the new production leg, both benign:

- `deploy-npm-packages` runs only on production, so it now runs during rotation. The target is idempotent — `npm view <pkg>@<version> ... || npm publish` — so it skips already-published versions. Costs a build, publishes nothing.
- `deploy-github-pages` is gated on `github.ref_name == 'main'`, not environment, so it runs in both legs. Its `concurrency: group: pages` serializes them and the second redeploys the same commit. Wasteful, not harmful — happy to gate it to the staging leg if preferred.

## Test plan

- [x] `check yaml` pre-commit hook passes on both workflow files
- [ ] `pnpm gh:actions:rotate-secrets` — confirm the run reaches `deploy-staging` and then `deploy-production`
- [ ] Confirm the second call's `run-name` reads `deploy (production)`
- [ ] Confirm `deploy-apps` in the production leg runs `nx run-many -t deploy:production`
- [ ] Confirm `production-vb-express` picks up the rotated `TWILIO_AUTH_TOKEN` without a manual deploy
- [ ] Confirm a normal push to `main` still deploys staging only (the no-default fallback is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)