### PR TITLE
fix(github-actions): Skip the pages deploy on rotation's production leg.

### DIFF
--- a/.github/workflows/ci-rotate-secrets.yml
+++ b/.github/workflows/ci-rotate-secrets.yml
@@ -133,4 +133,5 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       environment: production
+      skip_pages: true
     secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,10 @@ on:
       environment:
         description: 'Deployment environment'
         type: string
+      skip_pages:
+        description: 'Skip the GitHub Pages deploy — set by callers that invoke this workflow more than once per run, since the pages artifact name is unique per run, not per call'
+        type: boolean
+        default: false
 
 permissions:
   actions: read
@@ -215,7 +219,7 @@ jobs:
 
   deploy-github-pages:
     needs: gitleaks
-    if: ${{ github.ref_name == 'main' }}
+    if: ${{ github.ref_name == 'main' && !inputs.skip_pages }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment:


### PR DESCRIPTION
## Summary

Follow-up to #271, which made `ci-rotate-secrets` call `deploy.yml` twice. [Run 30724783183](https://github.com/iamharryliu/vigilant-broccoli/actions/runs/30724783183) then failed on `deploy-production / deploy-github-pages`:

```
Error: Multiple artifacts named "github-pages-1" were unexpectedly found
for this workflow run. Artifact count is 2.
```

- A reusable workflow call shares the **caller's** run, and the artifact name keys off `github.run_attempt` (`github-pages-${{ github.run_attempt }}`) — per-run, not per-call. Both legs uploaded `github-pages-1` into the same run and `actions/deploy-pages` refuses to pick between them.
- Added a `skip_pages` boolean input (default `false`) to `deploy.yml`'s `workflow_call`; `deploy-github-pages` is now gated on `github.ref_name == 'main' && !inputs.skip_pages`. `ci-rotate-secrets`'s `deploy-production` passes `skip_pages: true`.
- The pages artifact (component-library + pages-index) is environment-agnostic, so the staging leg alone covers a rotation run — the production leg had nothing to add.

Gated with `!inputs.skip_pages` rather than `inputs.skip_pages != true` on purpose: on `push` and `workflow_dispatch` the input is undefined, and GitHub casts both `null` and `false` to `0`, so an equality comparison against `false` would evaluate true and silently disable pages on every normal deploy.

Everything that passed in that run is unaffected — rotation, both `deploy-apps` legs, and production `deploy-npm-packages`.

## Test plan

- [x] `check yaml` pre-commit hook passes on both workflow files
- [ ] `pnpm gh:actions:rotate-secrets` — run completes green end to end
- [ ] `deploy-staging / deploy-github-pages` runs; `deploy-production / deploy-github-pages` is skipped
- [ ] Pages site still reflects the rotation run's commit
- [ ] Push to `main` still deploys pages (input undefined → not skipped)
- [ ] Manual `deploy` dispatch with `environment: production` still deploys pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)