### PR TITLE
ci(flyio): Reconcile private-only apps' IPs on every deploy

### DIFF
--- a/docs/api/deployment/fly-service-pattern.md
+++ b/docs/api/deployment/fly-service-pattern.md
@@ -57,4 +57,10 @@ Wiring: pruned `smoke` depends on `prune`; bundled `smoke` depends on `build`. `
 
 Declare in `projects/nx-workspace/scripts/secrets-mapping.config.ts`. The service's `.env.example` is the key list: `deploy-flyio-secrets.ts` parses it, pulls those keys from the service's Vault path, and pushes them with `flyctl secrets set`. `nx deploy:secrets <svc>` creates the fly app first if it doesn't exist yet (`flyctl apps create`); `deploy` depends on `deploy:secrets`, so a first deploy to a brand-new app works end-to-end (volumes declared in `[mounts]` are auto-created on first deploy).
 
+## Private-only services
+
+Set `privateOnly: true` in `secrets-mapping.config.ts` (llm-service, bucket-service). `deploy:secrets` then reconciles the app's IPs before every deploy: allocates a private ingress IPv6 if missing, and releases any public `v4`/`v6`/`shared_v4` it finds. Because `deploy` depends on `deploy:secrets`, a brand-new private service never has a public edge, and a public IP that reappears (some flyctl versions auto-allocate on first deploy when the config declares an `http_service`) is cleaned up on the next deploy rather than needing a human to notice.
+
+Pair it with `[http_service].force_https = false` — see [network-management.md](../../infrastructure/network-management.md) for why, and for how CI reaches these services.
+
 Both environments read the same Vault path — per-env secret values would need per-env vault paths.

--- a/docs/infrastructure/network-management.md
+++ b/docs/infrastructure/network-management.md
@@ -49,7 +49,9 @@ github.io                                 GitHub Pages
 
 ## Private-only Fly.io services
 
-Reachable only over Fly's private 6PN network via a flycast address — no public IPv4/IPv6 allocated, so the `fly.dev` hostname resolves to nothing reachable. Each app has a private ingress IPv6 (`fly ips allocate-v6 --private`) and `[http_service].force_https = false`, so the flycast edge serves the internal port over plain HTTP on port 80 (a `.internal` direct-machine dial would hit the app's IPv4-only `0.0.0.0` bind and reset; flycast routes through fly-proxy, which also auto-starts stopped machines).
+Reachable only over Fly's private 6PN network via a flycast address — no public IPv4/IPv6 allocated, so the `fly.dev` hostname resolves to nothing reachable. Each app has a private ingress IPv6 and `[http_service].force_https = false`, so the flycast edge serves the internal port over plain HTTP on port 80 (a `.internal` direct-machine dial would hit the app's IPv4-only `0.0.0.0` bind and reset; flycast routes through fly-proxy, which also auto-starts stopped machines).
+
+IP allocation is automated, not manual: services flagged `privateOnly: true` in `scripts/secrets-mapping.config.ts` get their private IPv6 allocated and any public IP released by `deploy:secrets` on every deploy — see [fly-service-pattern.md](../api/deployment/fly-service-pattern.md).
 
 ```
 staging-vb-llm-service.flycast            LLM Service (staging) — called by staging-vb-express via http://…flycast over 6PN

--- a/projects/nx-workspace/scripts/deploy-flyio-secrets.ts
+++ b/projects/nx-workspace/scripts/deploy-flyio-secrets.ts
@@ -47,6 +47,13 @@ const STAGING = 'staging';
 const PRODUCTION = 'production';
 const ENVIRONMENTS = [STAGING, PRODUCTION];
 
+const PRIVATE_V6_TYPE = 'private_v6';
+
+interface FlyIp {
+  Address: string;
+  Type: string;
+}
+
 function flyAppExists(appName: string): boolean {
   try {
     execSync(`flyctl status --app ${appName}`, { stdio: 'pipe' });
@@ -68,6 +75,43 @@ function ensureFlyApp(appName: string, dryRun = false): void {
   console.log(`Fly app ${appName} not found. Creating...`);
   runFlyctl(createCommand);
   console.log(`Created fly app ${appName}`);
+}
+
+function listFlyIps(appName: string): FlyIp[] {
+  try {
+    const output = execSync(`flyctl ips list --app ${appName} --json`, {
+      stdio: 'pipe',
+    }).toString();
+    return JSON.parse(output) as FlyIp[];
+  } catch {
+    return [];
+  }
+}
+
+function ensurePrivateNetworking(appName: string, dryRun = false): void {
+  const ips = dryRun && !flyAppExists(appName) ? [] : listFlyIps(appName);
+
+  if (!ips.some(ip => ip.Type === PRIVATE_V6_TYPE)) {
+    const allocateCommand = `flyctl ips allocate-v6 --private --app ${appName}`;
+    if (dryRun) {
+      console.log(`[DRY RUN] Would execute: ${allocateCommand}`);
+    } else {
+      console.log(`Allocating private IPv6 for ${appName}...`);
+      runFlyctl(allocateCommand);
+    }
+  }
+
+  for (const ip of ips.filter(i => i.Type !== PRIVATE_V6_TYPE)) {
+    const releaseCommand = `flyctl ips release ${ip.Address} --app ${appName}`;
+    if (dryRun) {
+      console.log(`[DRY RUN] Would execute: ${releaseCommand}`);
+    } else {
+      console.log(
+        `Releasing public ${ip.Type} ${ip.Address} from private-only app ${appName}...`,
+      );
+      runFlyctl(releaseCommand);
+    }
+  }
 }
 
 function getExistingSecretKeys(appName: string): string[] {
@@ -159,6 +203,10 @@ async function main() {
   );
 
   ensureFlyApp(flyAppName, dryRun);
+
+  if (config.privateOnly) {
+    ensurePrivateNetworking(flyAppName, dryRun);
+  }
 
   const envExamplePath = join(config.appPath, '.env.example');
   console.log(`Reading required secrets from ${envExamplePath}...`);

--- a/projects/nx-workspace/scripts/secrets-mapping.config.ts
+++ b/projects/nx-workspace/scripts/secrets-mapping.config.ts
@@ -3,6 +3,7 @@ export interface AppSecretsConfig {
   appPath: string;
   vaultPath: string;
   excludeEnvVars?: string[];
+  privateOnly?: boolean;
 }
 
 export interface SecretsMapping {
@@ -25,6 +26,7 @@ export const secretsMapping: SecretsMapping = {
     appPath: './apps/api/llm-service',
     vaultPath: COMMON_VAULT_PATH,
     excludeEnvVars: COMMON_EXCLUDED_VARS,
+    privateOnly: true,
   },
   'email-service': {
     flyAppBaseName: 'vb-email-service',
@@ -43,6 +45,7 @@ export const secretsMapping: SecretsMapping = {
     appPath: './apps/api/bucket-service',
     vaultPath: COMMON_VAULT_PATH,
     excludeEnvVars: COMMON_EXCLUDED_VARS,
+    privateOnly: true,
   },
   'vb-manager-next-mobile': {
     flyAppBaseName: 'vb-manager-next-mobile',


### PR DESCRIPTION
## Summary

Follow-up to #273. Allocating the private IPv6 and releasing public ones was a manual runbook step, so a private-only service was one forgotten command away from being publicly reachable — and some `flyctl` versions re-allocate a public IP on first deploy when the config declares an `http_service`, which nobody would notice without checking `fly ips list` by hand.

- Adds `privateOnly?: boolean` to `AppSecretsConfig`, set on `llm-service` and `bucket-service`.
- `deploy-flyio-secrets.ts` gains `ensurePrivateNetworking()`: allocates a private ingress IPv6 if absent, and releases any public `v4` / `v6` / `shared_v4` it finds. Runs right after `ensureFlyApp`, guarded by the flag so it can never touch a public service.
- `deploy` already depends on `deploy:secrets`, so a brand-new private service never gets a public edge, and a public IP that reappears is cleaned up on the next deploy instead of lingering.
- Documents the flag in `fly-service-pattern.md` and points `network-management.md` at it, replacing the "run `fly ips allocate-v6 --private` yourself" instruction.

## Verification

Ran the planner against the live apps (read-only):

| App | Current IPs | Planned action |
|---|---|---|
| `staging-vb-llm-service` | `private_v6` | none |
| `staging-storage-service` | `private_v6` | none |
| `production-storage-service` | `private_v6` | none |
| `staging-vb-storage-service` (old) | `v6`, `shared_v4` | allocate private v6, release both public |

Full `--dry-run` of the script against `bucket-service staging` and `llm-service production` completes end-to-end and correctly emits no IP commands for already-private apps.

## Test plan

- [ ] `nx run bucket-service:deploy:secrets` on staging logs no IP actions (already private-only)
- [ ] `nx run llm-service:deploy:secrets` / `:production` likewise no-op
- [ ] `flyctl ips list` on all four private apps still shows only a private v6 after a deploy
- [ ] Temporarily allocate a public v6 on a private app, redeploy, confirm it gets released
- [ ] A non-`privateOnly` service (`email-service`) is untouched — `deploy:secrets` emits no IP commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)