### PR TITLE
feat(pages-index): Replace back link with breadcrumb navigation

### DIFF
--- a/projects/nx-workspace/apps/ui/pages-index/src/app/components/Breadcrumb.tsx
+++ b/projects/nx-workspace/apps/ui/pages-index/src/app/components/Breadcrumb.tsx
@@ -1,0 +1,34 @@
+import { Fragment } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { ChevronRight } from 'lucide-react';
+import { useTranslation } from '../i18n';
+import { getBreadcrumbAncestors } from '../consts/breadcrumbs';
+
+interface BreadcrumbProps {
+  current: string;
+}
+
+export function Breadcrumb({ current }: BreadcrumbProps) {
+  const { t } = useTranslation();
+  const { pathname } = useLocation();
+  const ancestors = getBreadcrumbAncestors(pathname);
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="flex flex-wrap items-center gap-1 text-sm text-gray-500 dark:text-gray-400"
+    >
+      {ancestors.map(crumb => (
+        <Fragment key={crumb.path}>
+          <Link to={crumb.path} className="hover:underline">
+            {t(crumb.labelKey)}
+          </Link>
+          <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+        </Fragment>
+      ))}
+      <span aria-current="page" className="text-gray-700 dark:text-gray-300">
+        {current}
+      </span>
+    </nav>
+  );
+}

--- a/projects/nx-workspace/apps/ui/pages-index/src/app/components/PageHeader.tsx
+++ b/projects/nx-workspace/apps/ui/pages-index/src/app/components/PageHeader.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
-import { useTranslation } from '../i18n';
+import { Breadcrumb } from './Breadcrumb';
 
 interface PageHeaderProps {
   title: string;
@@ -8,16 +7,9 @@ interface PageHeaderProps {
 }
 
 export function PageHeader({ title, description }: PageHeaderProps) {
-  const { t } = useTranslation();
-
   return (
     <header className="mb-12">
-      <Link
-        to="/"
-        className="text-sm text-gray-500 dark:text-gray-400 hover:underline"
-      >
-        {t('COMMON.BACK')}
-      </Link>
+      <Breadcrumb current={title} />
       <h1 className="mt-2 text-3xl font-bold tracking-tight">{title}</h1>
       {description && (
         <p className="mt-2 text-gray-600 dark:text-gray-400">{description}</p>

--- a/projects/nx-workspace/apps/ui/pages-index/src/app/consts/breadcrumbs.ts
+++ b/projects/nx-workspace/apps/ui/pages-index/src/app/consts/breadcrumbs.ts
@@ -1,0 +1,57 @@
+import { DotPaths } from '@vigilant-broccoli/react-lib';
+import en from '../i18n/en.json';
+
+type TranslationKey = DotPaths<typeof en>;
+
+interface BreadcrumbNode {
+  labelKey: TranslationKey;
+  parent: string | null;
+}
+
+export interface BreadcrumbEntry {
+  path: string;
+  labelKey: TranslationKey;
+}
+
+const BREADCRUMB_TREE: Record<string, BreadcrumbNode> = {
+  '/': { labelKey: 'HOME.TITLE', parent: null },
+  '/ui': { labelKey: 'UI_PAGE.TITLE', parent: '/' },
+  '/status': { labelKey: 'STATUS_PAGE.TITLE', parent: '/' },
+  '/open-source': { labelKey: 'OPEN_SOURCE_PAGE.TITLE', parent: '/' },
+  '/open-source/github': {
+    labelKey: 'OPEN_SOURCE_PAGE.GITHUB.TITLE',
+    parent: '/open-source',
+  },
+  '/open-source/docker': {
+    labelKey: 'DOCKER_IMAGES_PAGE.TITLE',
+    parent: '/open-source',
+  },
+  '/open-source/npm': {
+    labelKey: 'NPM_PACKAGES_PAGE.TITLE',
+    parent: '/open-source',
+  },
+  '/web-applications': { labelKey: 'WEB_APPLICATIONS_PAGE.TITLE', parent: '/' },
+  '/api-services': { labelKey: 'API_SERVICES_PAGE.TITLE', parent: '/' },
+};
+
+const resolveParent = (pathname: string): string | null => {
+  const node = BREADCRUMB_TREE[pathname];
+  if (node) return node.parent;
+
+  const trimmed = pathname.slice(0, pathname.lastIndexOf('/')) || '/';
+  return trimmed !== pathname && BREADCRUMB_TREE[trimmed] ? trimmed : null;
+};
+
+export const getBreadcrumbAncestors = (pathname: string): BreadcrumbEntry[] => {
+  const crumbs: BreadcrumbEntry[] = [];
+  let current = resolveParent(pathname);
+
+  while (current) {
+    const node = BREADCRUMB_TREE[current];
+    if (!node) break;
+    crumbs.unshift({ path: current, labelKey: node.labelKey });
+    current = node.parent;
+  }
+
+  return crumbs;
+};

--- a/projects/nx-workspace/apps/ui/pages-index/src/app/i18n/en.json
+++ b/projects/nx-workspace/apps/ui/pages-index/src/app/i18n/en.json
@@ -1,7 +1,4 @@
 {
-  "COMMON": {
-    "BACK": "← Back"
-  },
   "HOME": {
     "TITLE": "vigilant-broccoli",
     "STATUS": {


### PR DESCRIPTION
## Summary
- Replace the hardcoded "← Back" link (always pointed to Home) in `PageHeader` with a full breadcrumb trail built from the route hierarchy.
- Add `consts/breadcrumbs.ts`, a small static path→parent map that resolves dynamic routes (`/open-source/docker/:image`, `/open-source/npm/:pkg`) to their static list-page parent, so the current page's already-resolved `title` prop supplies the final crumb.
- Remove the now-unused `COMMON.BACK` i18n key.

## Test plan
- [x] `pnpm nx run pages-index:lint` passes
- [x] `pnpm nx run pages-index:typecheck` passes (pre-existing, unrelated `StatusPage.tsx` error confirmed via `git stash`)
- [x] Manually verified in browser: deep nested route (`/open-source/docker/bucket-service`) renders `vigilant-broccoli › Open Source › Docker Hub › bucket-service`, and clicking a mid-chain crumb navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)