### PR TITLE
fix(pages-index): Float README external links right and fix TOC anchor jumps

### DIFF
--- a/projects/nx-workspace/apps/ui/pages-index/src/app/components/PageHeader.tsx
+++ b/projects/nx-workspace/apps/ui/pages-index/src/app/components/PageHeader.tsx
@@ -4,13 +4,17 @@ import { Breadcrumb } from './Breadcrumb';
 interface PageHeaderProps {
   title: string;
   description?: ReactNode;
+  action?: ReactNode;
 }
 
-export function PageHeader({ title, description }: PageHeaderProps) {
+export function PageHeader({ title, description, action }: PageHeaderProps) {
   return (
     <header className="mb-12">
       <Breadcrumb current={title} />
-      <h1 className="mt-2 text-3xl font-bold tracking-tight">{title}</h1>
+      <div className="mt-2 flex items-start justify-between gap-4">
+        <h1 className="text-3xl font-bold tracking-tight">{title}</h1>
+        {action && <div className="shrink-0 pt-1">{action}</div>}
+      </div>
       {description && (
         <p className="mt-2 text-gray-600 dark:text-gray-400">{description}</p>
       )}

--- a/projects/nx-workspace/apps/ui/pages-index/src/app/components/ReadmePage.tsx
+++ b/projects/nx-workspace/apps/ui/pages-index/src/app/components/ReadmePage.tsx
@@ -70,13 +70,13 @@ export function ReadmePage({
     <main className="mx-auto max-w-3xl px-6 py-16">
       <PageHeader
         title={title}
-        description={
+        action={
           externalHref && (
             <a
               href={externalHref}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 hover:underline"
+              className="inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-400 hover:underline"
             >
               {externalLabel}
               <ExternalLink className="h-3.5 w-3.5" />

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/note-links.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-utility/src/lib/note-links.ts
@@ -38,14 +38,26 @@ export const scrollToUrlHash = () => {
   document.getElementById(hash)?.scrollIntoView();
 };
 
+// In-page heading anchors (e.g. a Table of Contents link to "#stack") must not fall through
+// to the browser default: under HashRouter the URL's fragment IS the route, so letting the
+// browser navigate to "#stack" replaces the current route hash instead of scrolling.
+const isInPageAnchor = (href: string): boolean => href.startsWith('#');
+
 export const createNoteLinkClickHandler =
   (filePath: string, onNavigate?: (path: string) => void) =>
   (event: MouseEvent<HTMLElement>) => {
-    if (!onNavigate) return;
     const anchor = (event.target as HTMLElement).closest('a');
     if (!anchor) return;
     const href = anchor.getAttribute('href');
     if (!href) return;
+
+    if (isInPageAnchor(href)) {
+      event.preventDefault();
+      document.getElementById(href.slice(1))?.scrollIntoView();
+      return;
+    }
+
+    if (!onNavigate) return;
     const target = resolveNoteLink(filePath, href);
     if (target === null) return;
     event.preventDefault();


### PR DESCRIPTION
## Summary
- `PageHeader` gains an `action` slot rendered right-aligned on the title row; `ReadmePage`'s "View on Docker Hub / npm / GitHub" link now uses it instead of stacking below the title as a `description`.
- `note-links.ts`'s click handler now intercepts in-page `#anchor` clicks (markdown Table of Contents links) and scrolls to the target heading directly, instead of letting the browser rewrite `window.location.hash` — which under `HashRouter` is interpreted as a route change, breaking navigation (e.g. clicking `#stack` on the [email-service docker readme](https://iamharryliu.github.io/vigilant-broccoli/#/open-source/docker/email-service) previously routed to a nonexistent page instead of scrolling).

## Test plan
- [x] `pnpm exec eslint` on the three changed files (pre-existing warnings unrelated to this change confirmed present on `main`)
- [x] `nx run pages-index:typecheck` (pre-existing unrelated `StatusPage.tsx` error confirmed present on `main`)
- [x] Manually verified in Chrome via `nx serve pages-index`: "View on Docker Hub" renders right-aligned next to the title, and clicking the "Stack" TOC link scrolls to the heading while the URL stays at `#/open-source/docker/email-service`

🤖 Generated with [Claude Code](https://claude.com/claude-code)