### PR TITLE
security: Add CI check that private-only Fly services have no public IP

### DIFF
--- a/.github/workflows/test-security-private-network-exposure.yml
+++ b/.github/workflows/test-security-private-network-exposure.yml
@@ -1,0 +1,58 @@
+name: test-security-private-network-exposure
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Environment to test'
+        type: choice
+        default: all
+        options:
+          - all
+          - staging
+          - production
+  workflow_run:
+    workflows: ["deploy", "ci-rotate-secrets"]
+    types: [completed]
+    branches: [main, production]
+
+permissions:
+  contents: read
+
+jobs:
+  verify-no-public-ip:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ${{ fromJSON(github.event_name == 'workflow_run' && format('["{0}"]', github.event.workflow_run.head_branch == 'production' && 'production' || 'staging') || inputs.environment && inputs.environment != 'all' && format('["{0}"]', inputs.environment) || '["staging", "production"]') }}
+        # Every service flagged privateOnly:true in scripts/secrets-mapping.config.ts
+        # (flyAppBaseName values, not nx project names — e.g. bucket-service -> storage-service)
+        service:
+          - llm-service
+          - storage-service
+          - vb-email-service
+          - email-subscription-service
+    name: ${{ matrix.environment }}-${{ matrix.service }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Verify ${{ matrix.environment }}-${{ matrix.service }} has no public IP
+        run: |
+          APP="${{ matrix.environment }}-${{ matrix.service }}"
+          HTTP_CODE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "https://${APP}.fly.dev/" 2>/dev/null || echo "000")
+          echo "Response code: ${HTTP_CODE}"
+          if [ "${HTTP_CODE}" = "200" ]; then
+            echo "✗ https://${APP}.fly.dev/ responded 200 — this service is flagged privateOnly and should have no public IP"
+            exit 1
+          fi
+          echo "✓ ${APP}.fly.dev is not publicly reachable (${HTTP_CODE})"
+
+      - name: Notify on failure
+        if: failure()
+        run: |
+          echo "${{ matrix.environment }}-${{ matrix.service }} is publicly reachable! It should be private-only (Fly 6PN / flycast) — check deploy:secrets ran and released the public IP."
+          exit 1


### PR DESCRIPTION
## Summary

- Adds `test-security-private-network-exposure.yml`, a new scheduled/dispatchable workflow that directly curls each `privateOnly: true` service's public `https://<env>-<service>.fly.dev/` and fails if it responds `200`.
- Covers all four current private-only services (`llm-service`, `storage-service` (bucket-service), `vb-email-service`, `email-subscription-service`), matched to their `flyAppBaseName` in `scripts/secrets-mapping.config.ts`.
- This fills a gap: the existing `test-security-llm.yml` / `test-security-storage-service.yml` / `test-security-email.yml` / `test-security-email-subscription-service.yml` workflows check API-key auth, but they run over the `fly-private-tunnel` action, so they never actually probe the public edge — a leaked/re-allocated public IP would go unnoticed until someone manually curled it.
- No Vault secrets or tunnel needed — it's a plain unauthenticated request against the public internet, treating anything other than a clean `200` (connection failure, TLS failure, non-2xx) as "still locked down."

## Test plan

- [x] `check-yaml` pre-commit hook passes
- [ ] After merge: manually trigger via `workflow_dispatch` and confirm all four `staging-*` / `production-*` matrix entries pass (i.e. none respond 200)
- [ ] Confirm the workflow correctly fails if a public IP is manually re-allocated to one of these apps (spot check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)