### PR TITLE
enhancement(dotfiles): Neovide keybindings, tmux-safe save relay, and a config smoke test

### DIFF
--- a/.github/workflows/ci-pr-check.yml
+++ b/.github/workflows/ci-pr-check.yml
@@ -102,6 +102,11 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
 
+      # nvim-tmux-config-smoketest (see .pre-commit-config.yaml) needs a real nvim binary;
+      # tmux is already preinstalled on this image.
+      - name: Install neovim
+        run: sudo apt-get update && sudo apt-get install -y neovim
+
       - name: Run pre-commit
         env:
           SKIP: grind-75-tests,lint-staged

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,11 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+  - repo: local
+    hooks:
+      - id: nvim-tmux-config-smoketest
+        name: Run nvim/tmux custom config smoke test.
+        entry: ./setup/dotfiles/common/scripts/config-smoketest.sh
+        language: system
+        pass_filenames: false
+        files: ^setup/dotfiles/(\.config/nvim/|\.tmux\.conf$)

--- a/docs/cheatsheet-tmux-nvim.md
+++ b/docs/cheatsheet-tmux-nvim.md
@@ -1,0 +1,119 @@
+# Cheatsheet — Tmux & Nvim
+
+Keybindings for this repo's tmux + nvim setup (`setup/dotfiles/.tmux.conf`, `setup/dotfiles/.config/nvim/init.lua`). `PREFIX` = `ctrl + Space` (remapped from the tmux default `ctrl + b`).
+
+```
+🪟 TMUX — SESSIONS
+  tmux new -s NAME                          Create new session
+  tmux a -t NAME                            Attach to session
+  PREFIX + d                                Detach from session
+  PREFIX + S                                List sessions
+  PREFIX + $                                Rename session
+
+🧩 TMUX — WINDOWS
+  PREFIX + c                                Create new window
+  PREFIX + w                                List windows interactively
+  PREFIX + n / p                            Next / previous window
+  PREFIX + 0...9                            Jump to window by number
+  PREFIX + ,                                Rename current window
+  PREFIX + &                                Kill current window
+
+▦  TMUX — PANES (custom)
+  PREFIX + |                                Split pane side-by-side (in current path)
+  PREFIX + -                                Split pane top/bottom (in current path)
+  PREFIX + h/j/k/l                          Move focus left/down/up/right
+  PREFIX + z                                Zoom/unzoom current pane
+  PREFIX + o                                Cycle through all panes
+  PREFIX + x                                Kill current pane (confirm)
+  ctrl + d                                  Close pane (shell exit)
+  (default " / % / PREFIX+Space are unbound — use |/- above instead)
+
+📋 TMUX — COPY MODE & CLIPBOARD
+  PREFIX + [                                Enter copy mode
+  space                                     Start selection
+  y                                         Copy selection to system clipboard, exit copy mode
+  PREFIX + p                                Paste last copied content into pane (macOS only)
+  (OSC 52 everywhere; pbcopy/pbpaste bindings only added when macOS pbcopy is present —
+   on Linux, PREFIX+p stays tmux's default "previous window")
+
+🔗 TMUX — TMUXVB WORKFLOW
+  tmuxvb                                    Create/attach the "vb" session (2 windows: neovim, vb)
+  neovidetmuxvb                             Launch Neovide, auto-attach to "vb" via :terminal
+  (window 1 "neovim": Neovide's nested nvim `:terminal tmux attach -t vb`)
+  (window 2 "vb": 2 panes in repo root — one free, one running `claude`)
+
+✏️  NVIM — CORE
+  <leader>                                  Space (vim.g.mapleader = " ")
+  u                                         Undo
+  ctrl + r                                  Redo
+  ctrl + s                                  Save (works in any nvim instance, incl. nested)
+
+🌳 NVIM — NVIMTREE
+  :NvimTreeToggle                           Open/close the tree
+  :NvimTreeFindFile                         Open tree, highlight current buffer file
+  j / k                                     Move cursor up/down
+  h / l                                     Close folder (or go to parent) / open folder or file
+  Enter or o                                Open file or toggle folder
+  v / s / t                                 Open file in vsplit / split / new tab
+  a / r / d                                 Create / rename / delete file
+  c / x / p                                 Copy / cut / paste file
+
+📁 NVIM — OIL.NVIM
+  -                                         Open parent directory
+  <CR>                                      Open file or directory
+  <C-v> / <C-s>                             Open in vertical / horizontal split
+  g.                                        Toggle hidden files
+
+🔭 NVIM — TELESCOPE
+  <leader>ff                                Find files
+  <leader>fg                                Live grep
+  <leader>fb                                Find buffers
+  <leader>fw                                Find word under cursor
+  <CR> / <C-x> / <C-v> / <C-t>              Open file / hsplit / vsplit / new tab
+
+🧠 NVIM — LSP
+  gd / gD / gr / gI                         Go to definition / declaration / references / implementation
+  K                                         Hover documentation
+  <leader>rn                                Rename symbol
+  <leader>ca                                Code action
+  [d / ]d                                   Previous/next diagnostic
+  <leader>e                                 Show diagnostic under cursor
+
+✅ NVIM — COMPLETION
+  <C-Space>                                 Trigger completion
+  <C-n> / <C-p>                             Next / previous item
+  <CR>                                      Confirm selected item
+  <C-e>                                     Abort completion
+
+🎨 NVIM — FORMAT & LINT
+  <leader>lf                                Format buffer (also runs on save)
+  (linting runs automatically on save, buffer enter, leaving insert mode)
+
+🔍 NVIM — FZF
+  <C-p>                                     Find files
+  <C-g>                                     Ripgrep search in files
+  <C-b>                                     Search buffers
+
+🔀 NVIM — GIT DIFF / GITSIGNS
+  <leader>gd / gf / gc                      Open / show history for / close Git diff
+  ]c / [c                                   Jump to next / previous hunk
+  <leader>hs / hr / hp / hb                 Stage / reset / preview hunk / show line blame
+
+⌨️  NVIM — TERMINAL BUFFER (any :terminal)
+  i                                         Enter Terminal-Insert mode
+  <C-\><C-n>                                Exit Terminal-Insert mode, back to Normal
+  alt + Left / Right                        Move back/forward a word
+  alt + Backspace                           Delete previous word
+  :bd!                                      Force kill terminal buffer from Normal mode
+
+🖥️  NEOVIDE — CMD-KEY MAPPINGS (GUI only, vim.g.neovide gate)
+  cmd + c                                   Copy (normal/visual mode)
+  cmd + v                                   Paste (normal/insert/cmdline/terminal-insert)
+  cmd + s                                   Save — the only one forwarded into a :terminal
+                                             (sends raw Ctrl-S down the pty to a nested nvim)
+  cmd + w                                   Close buffer (:bdelete)
+  cmd + z / cmd + shift + z                 Undo / redo
+  cmd + t                                   New tab (:tabnew)
+  (w/z/shift+z/t are NOT forwarded into :terminal — use the native nvim keys above once nested;
+   forwarding Ctrl-Z there would trigger vim's own "suspend" instead of undo)
+```

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -8,6 +8,7 @@ Useful infra-level CLI commands, runnable via `pnpm run <script>`.
   open:repo:actions           Open GitHub Actions
   npm:packages                Open npm packages page
   cheatsheet                  Print this cheatsheet
+  cheatsheet:tmux-nvim        Print the tmux/nvim keybinding cheatsheet
 
 ⚙️  SETUP
   local:install:machine-setup Run machine setup installer (mac/linux)

--- a/notes/tech/software/os/shell/nvim.md
+++ b/notes/tech/software/os/shell/nvim.md
@@ -1,10 +1,11 @@
 # nvim
 
-- Default `<leader>` is `\`
+- `<leader>` is `<Space>` (`vim.g.mapleader = " "`, set in `init.lua`)
 
 ```
 u                                           # Undo
 ctrl + r                                    # Redo
+ctrl + s                                    # Save (custom, works in any nvim instance incl. nested)
 ```
 
 ## NvimTree
@@ -128,6 +129,7 @@ Linting (nvim-lint) runs automatically on save, buffer enter, and leaving insert
 ```
 neovide -- -c "terminal" -c "startinsert"   # Start Neovide as a dedicated terminal
 neovide -- -c "vsplit +term"                # Start with editor and terminal side-by-side
+neovidetmuxvb                               # Start Neovide attached to the "vb" tmux session (see tmux.md)
 
 
 # --- OPENING INSIDE NEOVIDE (NORMAL MODE) ---
@@ -142,7 +144,27 @@ i                                           # Enter Terminal-Insert mode (to typ
 <C-\><C-n>                                  # Exit Terminal-Insert mode (back to Normal mode)
 exit                                        # Close the shell and the buffer
 :bd!                                        # Force kill terminal buffer from Normal mode
+
+
+# --- TERMINAL BUFFER NAVIGATION (any :terminal, not just Neovide) ---
+alt + Left                                  # Move back a word (sends <Esc>b to the shell)
+alt + Right                                 # Move forward a word (sends <Esc>f to the shell)
+alt + Backspace                             # Delete previous word (sends <C-w> to the shell)
+
+
+# --- CUSTOM CMD-KEY MAPPINGS (only active when vim.g.neovide is true) ---
+cmd + c                                     # Copy (normal/visual mode)
+cmd + v                                     # Paste (normal/insert/cmdline/terminal-insert mode)
+cmd + s                                     # Save (normal/insert mode: :write)
+cmd + w                                     # Close buffer (normal mode: :bdelete)
+cmd + z                                     # Undo (normal mode)
+cmd + shift + z                             # Redo (normal mode)
+cmd + t                                     # New tab (normal mode: :tabnew)
 ```
+
+- These Cmd-key mappings only fire in Neovide's own buffers (`vim.g.neovide` gate in `init.lua`). Inside a `:terminal` buffer, nvim is in Terminal mode, a mode distinct from Normal/Insert — Cmd is a GUI-only modifier that never reaches whatever is running inside the terminal (tmux, a nested nvim, a shell), so none of these keys work there by default.
+- The one exception is `cmd + s`: Terminal mode has an explicit mapping that forwards a raw `Ctrl-S` byte down the pty, and `<C-s>` is bound globally (outside the Neovide gate) to `:write` — so it reaches a nested nvim (e.g. one running inside a `tmuxvb` pane) too.
+- The rest (`cmd + w/z/shift+z/t`) are intentionally _not_ forwarded into the terminal: once you're inside a nested nvim you already have the native keys (`u`, `<C-r>`, `:bd`, `:tabnew`) available directly, and blindly forwarding `Ctrl-Z` would trigger vim's own built-in "suspend" binding instead of undo.
 
 # Git Diff
 

--- a/notes/tech/software/os/shell/tmux.md
+++ b/notes/tech/software/os/shell/tmux.md
@@ -144,3 +144,35 @@ KEY_BIND + t                                        # Display a clock
 KEY_BIND + ?                                        # List all tmux shortcuts
 KEY_BIND + :                                        # Enter tmux command mode
 ```
+
+## Custom Setup (this repo's `.tmux.conf`)
+
+- Prefix key is remapped: `ctrl + Space` (not the default `ctrl + b`)
+- `mode-keys vi` — copy mode uses vi-style navigation
+- Mouse mode is on
+- Windows/panes are 1-indexed (`base-index`/`pane-base-index`), not 0-indexed
+
+```
+ctrl + Space                                        # Prefix (KEY_BIND above)
+
+# Panes
+PREFIX + |                                          # Split pane side-by-side, in current path
+PREFIX + -                                          # Split pane top/bottom, in current path
+PREFIX + h/j/k/l                                    # Move focus left/down/up/right (no arrows needed)
+
+# Clipboard (OSC 52 everywhere; pbcopy/pbpaste bindings added on macOS)
+y (in copy mode)                                     # Copy selection to system clipboard (pbcopy) and exit copy mode
+PREFIX + p                                          # Paste last pbcopy'd content into the pane
+```
+
+- Default `"`, `%`, and `PREFIX + Space` bindings are unbound (replaced by `|`/`-` above).
+- `allow-passthrough on` plus `TERM`/`TERM_PROGRAM` propagation is set for terminal image tools (e.g. yazi) to render correctly inside a pane.
+
+### `tmuxvb` workflow
+
+`tmuxvb` (alias → `setup/dotfiles/common/scripts/tmux-vb.sh`) creates/attaches a tmux session named `vb`:
+
+- Window 1 (`neovim`): runs `neovidetmuxvb`, which launches the Neovide GUI app; Neovide opens nvim, which immediately runs `:terminal tmux attach -t vb` (falling back to bootstrapping the session itself if `vb` doesn't exist yet) and drops straight into Terminal-insert mode.
+- Window 2 (`vb`): two panes in the repo root — one free for general work, one running `claude`.
+
+Since Neovide's `:terminal` buffer attaches back into the very same `vb` session, you end up viewing/controlling the `vb` tmux session through a terminal buffer hosted inside Neovide's own nvim instance. See [nvim.md](./nvim.md)'s Neovide section for which Cmd-key mappings do (and don't) carry through into that nested session, and why.

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "gh:actions:rotate-secrets": "gh workflow run ci-rotate-secrets --repo iamharryliu/vigilant-broccoli",
     "gh:actions:run-tests": "gh workflow run manual-run-tests --repo iamharryliu/vigilant-broccoli",
     "cheatsheet": "./scripts/shell/cheatsheet.sh",
+    "cheatsheet:tmux-nvim": "./scripts/shell/cheatsheet-tmux-nvim.sh",
     "audit": "python3 scripts/python/vuln_tree.py .",
     "nx:migrate": "cd projects/nx-workspace && nx migrate latest",
     "nx:migrate:run": "cd projects/nx-workspace && nx migrate --run-migrations"

--- a/scripts/shell/cheatsheet-tmux-nvim.sh
+++ b/scripts/shell/cheatsheet-tmux-nvim.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+sed -n '/^```$/,/^```$/p' "$SCRIPT_DIR/../../docs/cheatsheet-tmux-nvim.md" | sed '1d;$d'

--- a/setup/dotfiles/.config/nvim/init.lua
+++ b/setup/dotfiles/.config/nvim/init.lua
@@ -82,4 +82,8 @@ vim.api.nvim_create_autocmd("TermOpen", {
   end,
 })
 
-require("lazy").setup("plugins")
+-- Skip plugin loading under the config smoke test: it only exercises keymaps/options
+-- set above, and doing this avoids installing the whole plugin set on a cold CI runner.
+if not vim.env.NVIM_SMOKETEST then
+  require("lazy").setup("plugins")
+end

--- a/setup/dotfiles/.config/nvim/init.lua
+++ b/setup/dotfiles/.config/nvim/init.lua
@@ -30,7 +30,26 @@ if vim.g.neovide then
   vim.keymap.set("i", "<D-v>", "<C-r>+", { silent = true })
   vim.keymap.set("c", "<D-v>", "<C-r>+", { silent = true })
   vim.keymap.set("t", "<D-v>", [[<C-\><C-n>"+pi]], { silent = true })
+
+  -- Save
+  vim.keymap.set({ "n", "i" }, "<D-s>", "<cmd>write<CR>", { silent = true })
+  vim.keymap.set("t", "<D-s>", function()
+    vim.api.nvim_chan_send(vim.b.terminal_job_id, "\19")
+  end, { silent = true })
+
+  -- Close buffer
+  vim.keymap.set("n", "<D-w>", "<cmd>bdelete<CR>", { silent = true })
+
+  -- Undo/redo
+  vim.keymap.set("n", "<D-z>", "u", { silent = true })
+  vim.keymap.set("n", "<D-S-z>", "<C-r>", { silent = true })
+
+  -- New tab
+  vim.keymap.set("n", "<D-t>", "<cmd>tabnew<CR>", { silent = true })
 end
+
+-- Save (Ctrl-S), for every nvim instance including ones nested inside a terminal/tmux pane
+vim.keymap.set({ "n", "i" }, "<C-s>", "<cmd>write<CR>", { silent = true })
 
 vim.opt.clipboard = "unnamedplus"
 vim.opt.mouse = "a"

--- a/setup/dotfiles/common/scripts/config-smoketest.sh
+++ b/setup/dotfiles/common/scripts/config-smoketest.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Regression test for setup/dotfiles/.config/nvim/init.lua and setup/dotfiles/.tmux.conf:
+# catches accidental breakage of custom keymaps/options on future config edits.
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)
+NVIM_INIT="$REPO_ROOT/setup/dotfiles/.config/nvim/init.lua"
+TMUX_CONF="$REPO_ROOT/setup/dotfiles/.tmux.conf"
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+FAIL=0
+
+report() {
+  while IFS='|' read -r status name actual expected; do
+    [ -z "$status" ] && continue
+    if [ "$status" = "PASS" ]; then
+      echo "PASS: $name"
+    else
+      echo "FAIL: $name (expected [$expected], got [$actual])"
+      FAIL=1
+    fi
+  done < "$1"
+}
+
+# ---- nvim, simulating Neovide (vim.g.neovide = true) ----
+cat > "$WORKDIR/check_neovide.lua" <<'LUA'
+local results = {}
+
+local function mapping(mode, lhs)
+  local m = vim.fn.maparg(lhs, mode, false, true)
+  if not m or not m.lhs then return nil end
+  if m.callback then return "<function>" end
+  return m.rhs
+end
+
+local function check(name, actual, expected)
+  local pass
+  if expected == "<present>" then
+    pass = actual ~= nil
+  elseif expected == "<absent>" then
+    pass = actual == nil
+  else
+    pass = actual == expected
+  end
+  table.insert(results, string.format("%s|%s|%s|%s", pass and "PASS" or "FAIL", name, tostring(actual), tostring(expected)))
+end
+
+check("neovide n <D-c>", mapping("n", "<D-c>"), '"+y')
+check("neovide v <D-c>", mapping("v", "<D-c>"), '"+y')
+check("neovide n <D-v>", mapping("n", "<D-v>"), '"+p')
+check("neovide i <D-v>", mapping("i", "<D-v>"), "<C-r>+")
+check("neovide c <D-v>", mapping("c", "<D-v>"), "<C-r>+")
+check("neovide t <D-v>", mapping("t", "<D-v>"), [[<C-\><C-n>"+pi]])
+check("neovide n <D-s>", mapping("n", "<D-s>"), "<cmd>write<CR>")
+check("neovide i <D-s>", mapping("i", "<D-s>"), "<cmd>write<CR>")
+check("neovide t <D-s> (forwards Ctrl-S into terminal)", mapping("t", "<D-s>"), "<present>")
+check("neovide n <D-w>", mapping("n", "<D-w>"), "<cmd>bdelete<CR>")
+check("neovide n <D-z>", mapping("n", "<D-z>"), "u")
+check("neovide n <D-S-z>", mapping("n", "<D-S-z>"), "<C-r>")
+check("neovide n <D-t>", mapping("n", "<D-t>"), "<cmd>tabnew<CR>")
+check("global n <C-s>", mapping("n", "<C-s>"), "<cmd>write<CR>")
+check("global i <C-s>", mapping("i", "<C-s>"), "<cmd>write<CR>")
+
+check("mapleader", vim.g.mapleader, " ")
+check("opt clipboard", vim.o.clipboard, "unnamedplus")
+check("opt mouse", vim.o.mouse, "a")
+check("opt number", vim.o.number, true)
+check("opt relativenumber", vim.o.relativenumber, true)
+check("opt signcolumn", vim.o.signcolumn, "yes")
+check("opt tabstop", vim.o.tabstop, 2)
+check("opt shiftwidth", vim.o.shiftwidth, 2)
+check("opt expandtab", vim.o.expandtab, true)
+check("opt ignorecase", vim.o.ignorecase, true)
+check("opt smartcase", vim.o.smartcase, true)
+check("opt undofile", vim.o.undofile, true)
+check("opt scrolloff", vim.o.scrolloff, 8)
+
+-- TermOpen autocmd: local options + buffer-local terminal-mode keymaps
+vim.cmd("terminal")
+vim.wait(400)
+check("term local number", vim.wo.number, false)
+check("term local relativenumber", vim.wo.relativenumber, false)
+check("term local signcolumn", vim.wo.signcolumn, "no")
+check("term buffer <M-Left>", mapping("t", "<M-Left>"), "<Esc>b")
+check("term buffer <M-Right>", mapping("t", "<M-Right>"), "<Esc>f")
+check("term buffer <M-BS>", mapping("t", "<M-BS>"), "<C-w>")
+
+local f = io.open(os.getenv("SMOKETEST_OUT"), "w")
+for _, line in ipairs(results) do
+  f:write(line .. "\n")
+end
+f:close()
+vim.cmd("qa!")
+LUA
+
+SMOKETEST_OUT="$WORKDIR/neovide_results.txt" nvim --headless \
+  --cmd 'lua vim.g.neovide = true' \
+  -u "$NVIM_INIT" \
+  -S "$WORKDIR/check_neovide.lua" 2>"$WORKDIR/neovide_stderr.txt"
+report "$WORKDIR/neovide_results.txt"
+if [ -s "$WORKDIR/neovide_stderr.txt" ]; then
+  echo "FAIL: init.lua produced stderr output with vim.g.neovide=true"
+  cat "$WORKDIR/neovide_stderr.txt"
+  FAIL=1
+fi
+
+# ---- nvim, plain (no Neovide): D-* mappings must NOT leak out of the neovide gate ----
+cat > "$WORKDIR/check_plain.lua" <<'LUA'
+local results = {}
+
+local function mapping(mode, lhs)
+  local m = vim.fn.maparg(lhs, mode, false, true)
+  if not m or not m.lhs then return nil end
+  return true
+end
+
+local function check(name, actual, expected)
+  local pass = (expected == "<absent>") == (actual == nil)
+  table.insert(results, string.format("%s|%s|%s|%s", pass and "PASS" or "FAIL", name, tostring(actual), tostring(expected)))
+end
+
+check("plain n <D-s> absent", mapping("n", "<D-s>"), "<absent>")
+check("plain n <D-w> absent", mapping("n", "<D-w>"), "<absent>")
+check("plain n <D-z> absent", mapping("n", "<D-z>"), "<absent>")
+check("plain n <D-t> absent", mapping("n", "<D-t>"), "<absent>")
+check("plain n <C-s> present (must work in nested/plain nvim)", mapping("n", "<C-s>"), "<present>")
+
+local f = io.open(os.getenv("SMOKETEST_OUT"), "w")
+for _, line in ipairs(results) do
+  f:write(line .. "\n")
+end
+f:close()
+vim.cmd("qa!")
+LUA
+
+SMOKETEST_OUT="$WORKDIR/plain_results.txt" nvim --headless \
+  -u "$NVIM_INIT" \
+  -S "$WORKDIR/check_plain.lua" 2>"$WORKDIR/plain_stderr.txt"
+report "$WORKDIR/plain_results.txt"
+if [ -s "$WORKDIR/plain_stderr.txt" ]; then
+  echo "FAIL: init.lua produced stderr output without vim.g.neovide"
+  cat "$WORKDIR/plain_stderr.txt"
+  FAIL=1
+fi
+
+# ---- tmux: config must load cleanly, and custom prefix/bindings must be registered ----
+TMUX_SOCK="$WORKDIR/tmux.sock"
+if tmux -S "$TMUX_SOCK" -f "$TMUX_CONF" new-session -d -s smoketest 2>"$WORKDIR/tmux_stderr.txt"; then
+  echo "PASS: tmux config loads without error"
+else
+  echo "FAIL: tmux config failed to load"
+  cat "$WORKDIR/tmux_stderr.txt"
+  FAIL=1
+fi
+
+if [ -s "$WORKDIR/tmux_stderr.txt" ]; then
+  echo "FAIL: tmux config produced stderr output"
+  cat "$WORKDIR/tmux_stderr.txt"
+  FAIL=1
+fi
+
+PREFIX=$(tmux -S "$TMUX_SOCK" show-options -g prefix 2>/dev/null | awk '{print $2}')
+if [ "$PREFIX" = "C-Space" ]; then
+  echo "PASS: tmux prefix is C-Space"
+else
+  echo "FAIL: tmux prefix expected C-Space, got [$PREFIX]"
+  FAIL=1
+fi
+
+for key in '|' '-' h j k l; do
+  if tmux -S "$TMUX_SOCK" list-keys -T prefix 2>/dev/null | grep -qF " $key "; then
+    echo "PASS: tmux prefix binding for '$key' registered"
+  else
+    echo "FAIL: tmux prefix binding for '$key' missing"
+    FAIL=1
+  fi
+done
+
+tmux -S "$TMUX_SOCK" kill-server 2>/dev/null
+
+if [ "$FAIL" -eq 0 ]; then
+  echo "All config smoke tests passed."
+else
+  echo "Config smoke tests FAILED."
+fi
+exit $FAIL

--- a/setup/dotfiles/common/scripts/config-smoketest.sh
+++ b/setup/dotfiles/common/scripts/config-smoketest.sh
@@ -94,7 +94,7 @@ f:close()
 vim.cmd("qa!")
 LUA
 
-SMOKETEST_OUT="$WORKDIR/neovide_results.txt" nvim --headless \
+SMOKETEST_OUT="$WORKDIR/neovide_results.txt" NVIM_SMOKETEST=1 nvim --headless \
   --cmd 'lua vim.g.neovide = true' \
   -u "$NVIM_INIT" \
   -S "$WORKDIR/check_neovide.lua" 2>"$WORKDIR/neovide_stderr.txt"
@@ -104,6 +104,54 @@ if [ -s "$WORKDIR/neovide_stderr.txt" ]; then
   cat "$WORKDIR/neovide_stderr.txt"
   FAIL=1
 fi
+
+# ---- End-to-end: <D-s> pressed while attached to a terminal (e.g. a tmuxvb pane) must
+# actually forward a working Ctrl-S byte to whatever nvim is running inside it, not just
+# have *a* mapping registered (the "<present>" check above only proves that). This needs
+# a real --listen server + a separate --remote-send client: nvim_input()/:startinsert
+# called from within the same headless -S script never actually enters active Terminal
+# mode (mode() stays "nt"), since there's no attached UI client driving it.
+E2E_SOCK="$WORKDIR/e2e.sock"
+E2E_MARKER="$WORKDIR/e2e_marker.txt"
+E2E_RC="$WORKDIR/e2e_rc.lua"
+cat > "$E2E_RC" <<LUA
+vim.keymap.set("n", "<C-s>", function()
+  local f = io.open("$E2E_MARKER", "w")
+  f:write("saved")
+  f:close()
+end, {})
+LUA
+
+NVIM_SMOKETEST=1 nvim --headless --listen "$E2E_SOCK" --cmd 'lua vim.g.neovide = true' -u "$NVIM_INIT" >/dev/null 2>&1 &
+E2E_PID=$!
+
+waited=0
+while [ ! -S "$E2E_SOCK" ] && [ "$waited" -lt 5000 ]; do
+  sleep 0.1
+  waited=$((waited + 100))
+done
+
+nvim --server "$E2E_SOCK" --remote-expr "execute('terminal nvim --clean -u $E2E_RC')" >/dev/null 2>&1
+sleep 1.5
+nvim --server "$E2E_SOCK" --remote-expr "execute('startinsert')" >/dev/null 2>&1
+sleep 0.5
+nvim --server "$E2E_SOCK" --remote-send '<D-s>' >/dev/null 2>&1
+
+waited=0
+while [ ! -f "$E2E_MARKER" ] && [ "$waited" -lt 5000 ]; do
+  sleep 0.1
+  waited=$((waited + 100))
+done
+
+if [ -f "$E2E_MARKER" ]; then
+  echo "PASS: end-to-end <D-s> forwards Ctrl-S to a nested nvim inside the terminal"
+else
+  echo "FAIL: end-to-end <D-s> forwards Ctrl-S to a nested nvim inside the terminal"
+  FAIL=1
+fi
+
+kill "$E2E_PID" 2>/dev/null
+wait "$E2E_PID" 2>/dev/null
 
 # ---- nvim, plain (no Neovide): D-* mappings must NOT leak out of the neovide gate ----
 cat > "$WORKDIR/check_plain.lua" <<'LUA'
@@ -134,7 +182,7 @@ f:close()
 vim.cmd("qa!")
 LUA
 
-SMOKETEST_OUT="$WORKDIR/plain_results.txt" nvim --headless \
+SMOKETEST_OUT="$WORKDIR/plain_results.txt" NVIM_SMOKETEST=1 nvim --headless \
   -u "$NVIM_INIT" \
   -S "$WORKDIR/check_plain.lua" 2>"$WORKDIR/plain_stderr.txt"
 report "$WORKDIR/plain_results.txt"

--- a/setup/linux/apt-packages.txt
+++ b/setup/linux/apt-packages.txt
@@ -1,6 +1,7 @@
 tmux
 vim
 neovim
+xclip
 fzf
 ripgrep
 jq


### PR DESCRIPTION
## Summary
- Added Neovide Cmd-key mappings for save/close-buffer/undo/redo/new-tab (`<D-s>`, `<D-w>`, `<D-z>`, `<D-S-z>`, `<D-t>`), matching the existing `<D-c>`/`<D-v>` copy/paste mappings.
- Cmd (Super) can't survive a plain pty, so it never reached anything running inside a `:terminal` buffer (e.g. a nested nvim inside the `tmuxvb` workflow). Added a terminal-mode relay: `<D-s>` now forwards a raw `Ctrl-S` byte down the pty, and `<C-s>` is bound globally (not just under Neovide) to `:write`, so save works even in a nested session. The other keys (undo/redo/close/new-tab) are deliberately left unforwarded — they're already native vim keys once inside a nested nvim, and forwarding `Ctrl-Z` would trigger vim's own built-in "suspend" instead of undo.
- Added `xclip` to `setup/linux/apt-packages.txt` so `vim.opt.clipboard = "unnamedplus"` actually syncs with the system clipboard on a fresh Linux box (previously silently no-op'd without a clipboard provider installed).
- Documented the real custom mappings (replacing a stale note that still said leader was `\`) in `notes/tech/software/os/shell/nvim.md`, and the repo's actual `.tmux.conf` overrides + the `tmuxvb`/`neovidetmuxvb` workflow in `notes/tech/software/os/shell/tmux.md`.
- Added `setup/dotfiles/common/scripts/config-smoketest.sh`, a headless-nvim + isolated-tmux-server smoke test that asserts every custom keymap/option above, and wired it into `.pre-commit-config.yaml` (scoped to changes under `setup/dotfiles/.config/nvim/` or `.tmux.conf`) so future edits can't silently regress these.

## Test plan
Automated (already run, all passing):
- [x] `setup/dotfiles/common/scripts/config-smoketest.sh` — all keymap/option assertions pass
- [x] Deliberately broke a mapping locally and confirmed the smoke test caught it (then reverted)
- [x] `pre-commit run nvim-tmux-config-smoketest --files setup/dotfiles/.config/nvim/init.lua` — hook fires and passes

Manual (needs a real Neovide GUI / Linux box, please verify):
- [ ] Launch `neovide` directly: `Cmd+S` saves, `Cmd+W` closes the buffer (not the whole app window), `Cmd+Z`/`Cmd+Shift+Z` undo/redo, `Cmd+T` opens a new tab (`:tabs` shows 2)
- [ ] Run `tmuxvb` → confirm it opens Neovide attached to the `vb` tmux session as before (no change in the attach flow itself)
- [ ] Inside the `tmuxvb` pane, open a nested `nvim <file>`, edit it, press `Cmd+S` — confirm it saves (this is the main new behavior)
- [ ] Inside that same nested nvim, confirm `u` / `Ctrl-r` (undo/redo) and `:bd` / `:tabnew` still work natively as expected (unchanged, just confirming no regression)
- [ ] On a fresh/test Linux box: run the apt install step (or `setup/linux/install.sh`), confirm `xclip` installs, and that yanking in `nvim` and pasting into another app (or vice versa) actually works
- [ ] Confirm `.tmux.conf` still behaves interactively: prefix is `Ctrl+Space`, `PREFIX + |` / `PREFIX + -` split panes, `PREFIX + h/j/k/l` moves focus, copy-mode `y` copies via `pbcopy` on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)