### PR TITLE
feat(react-lib): Add shared D-keybind hook for theme toggling

### DIFF
--- a/projects/nx-workspace/apps/hearth/src/app/components/RootThemeWrapper.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/components/RootThemeWrapper.tsx
@@ -2,10 +2,15 @@
 
 import { ReactNode } from 'react';
 import { Theme } from '@radix-ui/themes';
-import { ThemeProvider, useTheme } from '@vigilant-broccoli/react-lib';
+import {
+  ThemeProvider,
+  useTheme,
+  useThemeKeybind,
+} from '@vigilant-broccoli/react-lib';
 
 function ThemedRadixWrapper({ children }: { children: ReactNode }) {
   const { appearance } = useTheme();
+  useThemeKeybind();
   return <Theme appearance={appearance}>{children}</Theme>;
 }
 

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/layout.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/layout.tsx
@@ -8,7 +8,7 @@ import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { useAuth } from '../../../libs/auth';
 import { APP_ROUTE } from '../app.const';
-import { useTheme } from '@vigilant-broccoli/react-lib';
+import { useTheme, useThemeKeybind } from '@vigilant-broccoli/react-lib';
 import { FloatingIslandComponent } from '../components/floating-island.component';
 import { RightSidebar } from '../components/right-sidebar.component';
 import { useDeployNotifications } from '../hooks/useDeployNotifications';
@@ -42,7 +42,6 @@ type KeyboardHandlers = {
   setWeatherDialogOpen: (open: boolean) => void;
   setPomodoroDialogOpen: (open: boolean) => void;
   setUtilitiesDialogOpen: (open: boolean) => void;
-  toggleTheme: () => void;
 };
 
 // eslint-disable-next-line complexity
@@ -83,9 +82,6 @@ const processKeyboardInput = (
     case 'u':
       handlers.setUtilitiesDialogOpen(true);
       return true;
-    case 'd':
-      handlers.toggleTheme();
-      return true;
     default:
       return false;
   }
@@ -105,7 +101,8 @@ const handleKeyboardShortcut = (
 };
 
 export default function Layout({ children }: { children: ReactNode }) {
-  const { appearance, toggleTheme } = useTheme();
+  const { appearance } = useTheme();
+  useThemeKeybind();
   const pathname = usePathname();
   const _session = useAuth();
   const { notifications, unreadCount, add, markAllRead, clear } =
@@ -158,13 +155,12 @@ export default function Layout({ children }: { children: ReactNode }) {
         setWeatherDialogOpen,
         setPomodoroDialogOpen,
         setUtilitiesDialogOpen,
-        toggleTheme,
       });
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [toggleTheme]);
+  }, []);
 
   return (
     <NotificationContext.Provider value={add}>

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/hooks/useThemeKeybind.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/hooks/useThemeKeybind.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useTheme } from '../components/ThemeProvider';
+
+const TOGGLE_KEY = 'd';
+const IGNORED_TAGS = ['INPUT', 'TEXTAREA', 'SELECT'];
+
+const isIgnoredInputElement = (target: EventTarget | null): boolean =>
+  target instanceof HTMLElement &&
+  (IGNORED_TAGS.includes(target.tagName) || target.isContentEditable);
+
+const shouldIgnoreKeystroke = (e: KeyboardEvent): boolean =>
+  isIgnoredInputElement(e.target) || e.ctrlKey || e.metaKey || e.altKey;
+
+export function useThemeKeybind() {
+  const { toggleTheme } = useTheme();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (shouldIgnoreKeystroke(e)) {
+        return;
+      }
+      if (e.key.toLowerCase() === TOGGLE_KEY) {
+        e.preventDefault();
+        toggleTheme();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [toggleTheme]);
+}

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/index.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/index.ts
@@ -1,6 +1,7 @@
 export * from './auth';
 export * from './components';
 export * from './hooks/useGeolocation';
+export * from './hooks/useThemeKeybind';
 export * from './i18n';
 export * from './leaderboard';
 export * from './live-location';


### PR DESCRIPTION
## Summary
- Added `useThemeKeybind()` to `@vigilant-broccoli/react-lib`, a reusable hook that toggles light/dark theme on the `D` key (ignoring input/textarea/select/contentEditable focus and modifier-key combos).
- Wired it into `hearth`'s `RootThemeWrapper`, which previously had no keybind.
- Replaced vb-manager-next's local `case 'd'` in its app-specific keyboard-shortcut dispatcher with the shared hook, avoiding duplicate/conflicting listeners.

## Test plan
- [x] `tsc --noEmit` passes for `react-lib`, `hearth`, and `vb-manager-next`
- [x] `nx lint` passes with no new warnings on all three projects
- [ ] Manually verify `D` toggles theme in hearth and vb-manager-next (and is ignored while typing in inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)