### PR TITLE
fix(hearth): Tighten vertical spacing on the settings page

### DIFF
--- a/projects/nx-workspace/apps/hearth/src/app/homes/components/HomeDetailView.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/homes/components/HomeDetailView.tsx
@@ -116,7 +116,7 @@ export const HomeDetailView = ({ homeId }: Props) => {
   if (!loaded) return null;
 
   return (
-    <div className="space-y-8">
+    <div className="space-y-5">
       <div className="space-y-4">
         <HomeForm
           name={name}

--- a/projects/nx-workspace/apps/hearth/src/app/settings/page.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/settings/page.tsx
@@ -157,7 +157,7 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="max-w-2xl mx-auto p-6 space-y-8">
+    <div className="max-w-2xl mx-auto p-6 space-y-6">
       <Text size="6" weight="bold">
         Settings
       </Text>
@@ -181,7 +181,7 @@ export default function SettingsPage() {
           {EXPORT_OPTIONS.map(({ key, label }) => (
             <label
               key={key}
-              className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-gray-50"
+              className="flex items-center gap-3 px-4 py-2 cursor-pointer hover:bg-gray-50"
             >
               <Checkbox
                 checked={selected.has(key)}
@@ -254,7 +254,7 @@ export default function SettingsPage() {
           Clear all records for the selected home. This is irreversible.
         </Text>
         <div className="border border-red-100 rounded-lg divide-y divide-red-50">
-          <label className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-red-50">
+          <label className="flex items-center gap-3 px-4 py-2 cursor-pointer hover:bg-red-50">
             <Checkbox
               checked={allClearSelected}
               onCheckedChange={toggleAllClear}
@@ -266,7 +266,7 @@ export default function SettingsPage() {
           {CLEAR_OPTIONS.map(({ key, label }) => (
             <label
               key={key}
-              className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-red-50"
+              className="flex items-center gap-3 px-4 py-2 cursor-pointer hover:bg-red-50"
             >
               <Checkbox
                 checked={clearSelected.has(key)}


### PR DESCRIPTION
## Summary
- `HomeDetailView` nested its own `space-y-8` inside the "Home" section, which already had 32px of separation from the page's other top-level sections — doubling up the gap right around the Members list. Tightened to `space-y-5`.
- Tightened the page's own top-level section spacing (`space-y-8` → `space-y-6`).
- Trimmed the checkbox-list row padding (`py-3` → `py-2`) in Export Data and the 12-row Dev/Clear-Options list, which was the main contributor to the page feeling overly tall.
- Left the shared `CRUDItemList` component (used by every other CRUD list in the app) untouched — its padding is a separate, broader call.

## Test plan
- [x] `tsc --noEmit` passes for `hearth`
- [x] `nx lint` passes with no new warnings
- [ ] Visually confirm on `staging-hearth` that `/settings` spacing looks right

🤖 Generated with [Claude Code](https://claude.com/claude-code)