### PR TITLE
feat(hearth): Add printable QR-code labels to Where Is storage areas

### DIFF
--- a/projects/nx-workspace/apps/hearth/src/app/api/qr-code/route.ts
+++ b/projects/nx-workspace/apps/hearth/src/app/api/qr-code/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest } from 'next/server';
+import { HTTP_STATUS_CODES } from '@vigilant-broccoli/common-js';
+import { QRCodeService } from '@vigilant-broccoli/common-node';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: NextRequest) {
+  const { url } = await request.json();
+  if (!url) {
+    return Response.json(
+      { error: 'url is required' },
+      { status: HTTP_STATUS_CODES.BAD_REQUEST },
+    );
+  }
+  const dataUrl = await QRCodeService.generateDataUrl(url);
+  return Response.json({ dataUrl });
+}

--- a/projects/nx-workspace/apps/hearth/src/app/where-is/[id]/page.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/where-is/[id]/page.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '../../providers/auth-provider';
 import { WhereIsItem } from '../../../lib/types';
 import { ROUTES } from '../../../lib/routes';
 import { WhereIsFormComponent, WhereIsFormValues } from '../where-is-form';
+import { WhereIsLabel } from '../where-is-label';
 
 const WHERE_IS_COPY = {
   LIST: { TITLE: 'Storage Areas', EMPTY_MESSAGE: '' },
@@ -90,64 +91,68 @@ export default function WhereIsDetailPage() {
 
   return (
     <div className="max-w-3xl mx-auto p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <Text size="6" weight="bold">
-          {item.title}
-        </Text>
-        <EllipsisCTA
-          onUpdate={() => setUpdateOpen(true)}
-          onDelete={handleDelete}
-        />
-      </div>
-
-      <CRUDItemFormDialog
-        open={updateOpen}
-        onOpenChange={setUpdateOpen}
-        formType={FORM_TYPE.UPDATE}
-        initialFormValues={formValues}
-        FormComponent={WhereIsFormComponent as never}
-        submitHandler={handleUpdate as never}
-        copy={WHERE_IS_COPY}
-      />
-
-      {item.description && (
-        <Text size="3" color="gray" as="p">
-          {item.description}
-        </Text>
-      )}
-
-      {item.tags.length > 0 && (
-        <div className="flex gap-2 flex-wrap">
-          {item.tags.map(tag => (
-            <Badge key={tag} variant="soft" size="2">
-              {tag}
-            </Badge>
-          ))}
+      <div className="print:hidden space-y-6">
+        <div className="flex items-center justify-between">
+          <Text size="6" weight="bold">
+            {item.title}
+          </Text>
+          <EllipsisCTA
+            onUpdate={() => setUpdateOpen(true)}
+            onDelete={handleDelete}
+          />
         </div>
-      )}
 
-      {item.imageUrls.length > 0 && (
-        <>
-          <StackedImages urls={item.imageUrls} alt={item.title} size={120} />
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            {item.imageUrls.map((url, i) => (
-              <img
-                key={i}
-                src={url}
-                alt={`${item.title} ${i + 1}`}
-                className="w-full rounded-lg object-cover"
-              />
+        <CRUDItemFormDialog
+          open={updateOpen}
+          onOpenChange={setUpdateOpen}
+          formType={FORM_TYPE.UPDATE}
+          initialFormValues={formValues}
+          FormComponent={WhereIsFormComponent as never}
+          submitHandler={handleUpdate as never}
+          copy={WHERE_IS_COPY}
+        />
+
+        {item.description && (
+          <Text size="3" color="gray" as="p">
+            {item.description}
+          </Text>
+        )}
+
+        {item.tags.length > 0 && (
+          <div className="flex gap-2 flex-wrap">
+            {item.tags.map(tag => (
+              <Badge key={tag} variant="soft" size="2">
+                {tag}
+              </Badge>
             ))}
           </div>
-        </>
-      )}
+        )}
 
-      <Text size="1" color="gray" as="p">
-        Added{' '}
-        {new Date(item.createdAt).toLocaleDateString(undefined, {
-          dateStyle: 'medium',
-        })}
-      </Text>
+        {item.imageUrls.length > 0 && (
+          <>
+            <StackedImages urls={item.imageUrls} alt={item.title} size={120} />
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {item.imageUrls.map((url, i) => (
+                <img
+                  key={i}
+                  src={url}
+                  alt={`${item.title} ${i + 1}`}
+                  className="w-full rounded-lg object-cover"
+                />
+              ))}
+            </div>
+          </>
+        )}
+
+        <Text size="1" color="gray" as="p">
+          Added{' '}
+          {new Date(item.createdAt).toLocaleDateString(undefined, {
+            dateStyle: 'medium',
+          })}
+        </Text>
+      </div>
+
+      <WhereIsLabel itemId={item.id} title={item.title} />
     </div>
   );
 }

--- a/projects/nx-workspace/apps/hearth/src/app/where-is/where-is-label.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/where-is/where-is-label.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Text } from '@radix-ui/themes';
+import { Button } from '@vigilant-broccoli/react-lib';
+import { ROUTES } from '../../lib/routes';
+
+const QR_CODE_ENDPOINT = '/api/qr-code';
+const PRINT_LABEL = 'Print Label';
+
+type Props = {
+  itemId: string;
+  title: string;
+};
+
+export const WhereIsLabel = ({ itemId, title }: Props) => {
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const detailUrl = `${window.location.origin}${ROUTES.WHERE_IS_DETAIL(itemId)}`;
+    fetch(QR_CODE_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: detailUrl }),
+    })
+      .then(r => r.json())
+      .then(data => setQrDataUrl(data.dataUrl));
+  }, [itemId]);
+
+  if (!qrDataUrl) return null;
+
+  return (
+    <div className="flex flex-col items-center gap-3 print:justify-center print:h-screen">
+      <div className="flex flex-col items-center gap-2 border border-gray-200 rounded-lg p-4 print:border-none">
+        <img
+          src={qrDataUrl}
+          alt={`QR code linking to ${title}`}
+          className="h-40 w-40"
+        />
+        <Text size="2" weight="medium">
+          {title}
+        </Text>
+      </div>
+      <Button
+        variant="outline"
+        onClick={() => window.print()}
+        className="print:hidden"
+      >
+        {PRINT_LABEL}
+      </Button>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Added `apps/hearth/src/app/api/qr-code/route.ts`, a thin route reusing the existing `QRCodeService` from `@vigilant-broccoli/common-node` (already used the same way in vb-manager-next) to turn a URL into a QR data URL.
- Added `where-is-label.tsx`: fetches a QR code pointing at the storage area's detail URL and renders it with a "Print Label" button.
- Wrapped the rest of the detail page's content in `print:hidden` so printing only produces the QR + title label (clean sticker output), not the whole page.
- Ties the physical location back to the app: print the label, stick it on the shelf, scan to jump straight to that storage area's photos/description.

## Test plan
- [x] `tsc --noEmit` passes for `hearth`
- [x] `nx lint` passes with no new warnings
- [ ] Manually confirm the QR code scans to the correct detail URL and that `window.print()` output shows only the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)