### PR TITLE
feat(whiteboard): Show each collaborator's text caret

### DIFF
--- a/projects/nx-workspace/apps/whiteboard/src/app/components/WhiteboardApp.tsx
+++ b/projects/nx-workspace/apps/whiteboard/src/app/components/WhiteboardApp.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   CONNECTION_STATUS,
   useWhiteboardRoom,
 } from '../hooks/useWhiteboardRoom';
 import { useTranslation } from '../i18n';
+import { CaretCoordinates, getCaretCoordinates } from '../utils/caret-position';
 
 const USER_PREFIX = 'user-';
 const USER_ID_LENGTH = 6;
@@ -118,11 +119,17 @@ export function WhiteboardApp() {
     members,
     cursors,
     setCursorPosition,
+    setTextCursorIndex,
     connectionStatus,
   } = useWhiteboardRoom(activeRoom, userId, username);
 
   const boardRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const lastCursorSentAtRef = useRef(0);
+  const lastIndexSentAtRef = useRef(0);
+  const [caretPositions, setCaretPositions] = useState<
+    Record<string, CaretCoordinates>
+  >({});
 
   const handleBoardMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
     const now = Date.now();
@@ -139,6 +146,17 @@ export function WhiteboardApp() {
 
   const handleBoardMouseLeave = () => setCursorPosition(null, null);
 
+  const sendTextCursorIndex = () => {
+    const now = Date.now();
+    if (now - lastIndexSentAtRef.current < CURSOR_SEND_INTERVAL_MS) return;
+    lastIndexSentAtRef.current = now;
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    setTextCursorIndex(textarea.selectionStart);
+  };
+
+  const handleTextBlur = () => setTextCursorIndex(null);
+
   const membersLabel =
     members.length <= SINGLE_MEMBER
       ? t('MEMBERS.COUNT_ONE')
@@ -148,6 +166,38 @@ export function WhiteboardApp() {
     cursor =>
       cursor.userId !== userId && cursor.x !== null && cursor.y !== null,
   );
+
+  const peerTextCursors = cursors.filter(
+    cursor => cursor.userId !== userId && cursor.index !== null,
+  );
+
+  const recomputeCaretPositions = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const next: Record<string, CaretCoordinates> = {};
+    peerTextCursors.forEach(cursor => {
+      const index = Math.min(cursor.index as number, content.length);
+      const coords = getCaretCoordinates(textarea, index);
+      next[cursor.userId] = {
+        top: coords.top - textarea.scrollTop,
+        left: coords.left - textarea.scrollLeft,
+        height: coords.height,
+      };
+    });
+    setCaretPositions(next);
+  }, [peerTextCursors, content]);
+
+  useEffect(() => {
+    recomputeCaretPositions();
+  }, [recomputeCaretPositions]);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.addEventListener('scroll', recomputeCaretPositions);
+    return () =>
+      textarea.removeEventListener('scroll', recomputeCaretPositions);
+  }, [recomputeCaretPositions]);
 
   return (
     <div className="flex flex-col h-[100dvh] bg-gray-50">
@@ -255,15 +305,47 @@ export function WhiteboardApp() {
             ref={boardRef}
             onMouseMove={handleBoardMouseMove}
             onMouseLeave={handleBoardMouseLeave}
-            className="relative flex-1 min-h-0"
+            className="relative flex-1 min-h-0 overflow-hidden"
           >
             <textarea
+              ref={textareaRef}
               value={content}
-              onChange={e => setContent(e.target.value)}
+              onChange={e => {
+                setContent(e.target.value);
+                sendTextCursorIndex();
+              }}
+              onSelect={sendTextCursorIndex}
+              onBlur={handleTextBlur}
               placeholder={t('BOARD.PLACEHOLDER')}
               disabled={connectionStatus !== CONNECTION_STATUS.CONNECTED}
               className="h-full w-full resize-none rounded border border-gray-300 p-3 font-mono text-sm leading-relaxed text-gray-800 focus:border-blue-500 focus:outline-none disabled:bg-gray-100"
             />
+            {peerTextCursors.map(cursor => {
+              const position = caretPositions[cursor.userId];
+              if (!position) return null;
+              return (
+                <div
+                  key={cursor.userId}
+                  style={{
+                    top: position.top,
+                    left: position.left,
+                    height: position.height,
+                  }}
+                  className="pointer-events-none absolute z-10 overflow-visible"
+                >
+                  <span
+                    style={{ backgroundColor: cursorColor(cursor.userId) }}
+                    className="block h-full w-0.5 animate-pulse"
+                  />
+                  <span
+                    style={{ backgroundColor: cursorColor(cursor.userId) }}
+                    className="absolute bottom-full left-0 mb-0.5 inline-block rounded px-1.5 py-0.5 text-xs whitespace-nowrap text-white shadow"
+                  >
+                    {cursor.username}
+                  </span>
+                </div>
+              );
+            })}
             {peerCursors.map(cursor => (
               <div
                 key={cursor.userId}

--- a/projects/nx-workspace/apps/whiteboard/src/app/utils/caret-position.ts
+++ b/projects/nx-workspace/apps/whiteboard/src/app/utils/caret-position.ts
@@ -1,0 +1,60 @@
+const MIRROR_OFFSCREEN_LEFT = '-9999px';
+const FALLBACK_CHARACTER = '.';
+
+export interface CaretCoordinates {
+  top: number;
+  left: number;
+  height: number;
+}
+
+// Measures where a character index would render inside a <textarea> by
+// laying the same text out in a hidden mirror div with matching font
+// metrics, then reading the offset of a marker span placed at that index.
+export function getCaretCoordinates(
+  textarea: HTMLTextAreaElement,
+  index: number,
+): CaretCoordinates {
+  const style = window.getComputedStyle(textarea);
+  const paddingLeft = parseFloat(style.paddingLeft);
+  const paddingTop = parseFloat(style.paddingTop);
+  const borderLeft = parseFloat(style.borderLeftWidth);
+  const borderTop = parseFloat(style.borderTopWidth);
+  const contentWidth =
+    textarea.clientWidth - paddingLeft - parseFloat(style.paddingRight);
+
+  const mirror = document.createElement('div');
+  mirror.style.position = 'absolute';
+  mirror.style.visibility = 'hidden';
+  mirror.style.top = '0';
+  mirror.style.left = MIRROR_OFFSCREEN_LEFT;
+  mirror.style.width = `${contentWidth}px`;
+  mirror.style.whiteSpace = 'pre-wrap';
+  mirror.style.wordWrap = 'break-word';
+  mirror.style.wordBreak = style.wordBreak;
+  mirror.style.fontFamily = style.fontFamily;
+  mirror.style.fontSize = style.fontSize;
+  mirror.style.fontWeight = style.fontWeight;
+  mirror.style.fontStyle = style.fontStyle;
+  mirror.style.lineHeight = style.lineHeight;
+  mirror.style.letterSpacing = style.letterSpacing;
+  mirror.style.tabSize = style.tabSize;
+
+  const value = textarea.value;
+  mirror.textContent = value.substring(0, index);
+
+  const marker = document.createElement('span');
+  const nextChar = value.charAt(index);
+  marker.textContent =
+    nextChar && nextChar !== '\n' ? nextChar : FALLBACK_CHARACTER;
+  mirror.appendChild(marker);
+
+  document.body.appendChild(mirror);
+  const coordinates: CaretCoordinates = {
+    top: marker.offsetTop + paddingTop + borderTop,
+    left: marker.offsetLeft + paddingLeft + borderLeft,
+    height: marker.offsetHeight,
+  };
+  document.body.removeChild(mirror);
+
+  return coordinates;
+}

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/whiteboard/useWhiteboardRoom.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/whiteboard/useWhiteboardRoom.ts
@@ -41,6 +41,7 @@ interface CursorPayload {
   username: string;
   x: number | null;
   y: number | null;
+  index: number | null;
   updatedAt: number;
 }
 
@@ -93,6 +94,11 @@ export function useWhiteboardRoom(
   const updatedAtRef = useRef<number>(0);
   const contentRef = useRef<string>('');
   const cursorsRef = useRef<Record<string, WhiteboardCursor>>({});
+  const ownCursorRef = useRef<{
+    x: number | null;
+    y: number | null;
+    index: number | null;
+  }>({ x: null, y: null, index: null });
 
   useEffect(() => {
     usernameRef.current = username;
@@ -142,6 +148,7 @@ export function useWhiteboardRoom(
           username: payload.username,
           x: payload.x,
           y: payload.y,
+          index: payload.index,
           updatedAt: payload.updatedAt,
         },
       };
@@ -196,6 +203,7 @@ export function useWhiteboardRoom(
       setContentState('');
       cursorsRef.current = {};
       setCursors([]);
+      ownCursorRef.current = { x: null, y: null, index: null };
     };
   }, [supabase, channelName, userId]);
 
@@ -211,21 +219,35 @@ export function useWhiteboardRoom(
     });
   }, []);
 
+  const sendOwnCursor = useCallback(() => {
+    channelRef.current?.send({
+      type: BROADCAST_EVENT,
+      event: CURSOR_EVENT,
+      payload: {
+        userId,
+        username: usernameRef.current,
+        x: ownCursorRef.current.x,
+        y: ownCursorRef.current.y,
+        index: ownCursorRef.current.index,
+        updatedAt: Date.now(),
+      },
+    });
+  }, [userId]);
+
   const setCursorPosition = useCallback(
     (x: number | null, y: number | null) => {
-      channelRef.current?.send({
-        type: BROADCAST_EVENT,
-        event: CURSOR_EVENT,
-        payload: {
-          userId,
-          username: usernameRef.current,
-          x,
-          y,
-          updatedAt: Date.now(),
-        },
-      });
+      ownCursorRef.current = { ...ownCursorRef.current, x, y };
+      sendOwnCursor();
     },
-    [userId],
+    [sendOwnCursor],
+  );
+
+  const setTextCursorIndex = useCallback(
+    (index: number | null) => {
+      ownCursorRef.current = { ...ownCursorRef.current, index };
+      sendOwnCursor();
+    },
+    [sendOwnCursor],
   );
 
   return {
@@ -234,6 +256,7 @@ export function useWhiteboardRoom(
     members,
     cursors,
     setCursorPosition,
+    setTextCursorIndex,
     connectionStatus,
   };
 }

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/whiteboard/whiteboard-room.types.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/whiteboard/whiteboard-room.types.ts
@@ -10,6 +10,7 @@ export interface WhiteboardCursor {
   username: string;
   x: number | null;
   y: number | null;
+  index: number | null;
   updatedAt: number;
 }
 
@@ -19,5 +20,6 @@ export interface WhiteboardRoomState {
   members: WhiteboardMember[];
   cursors: WhiteboardCursor[];
   setCursorPosition: (x: number | null, y: number | null) => void;
+  setTextCursorIndex: (index: number | null) => void;
   connectionStatus: ConnectionStatus;
 }


### PR DESCRIPTION
## Summary
- Follow-up to #293: adds a Google-Docs-style colored text caret + username label at each collaborator's actual typing position (character offset in the shared textarea), alongside the existing mouse pointer indicator.
- Caret pixel position is measured with a hidden mirror-div technique matching the textarea's computed font/wrapping/padding.
- Position is recomputed on content change and on textarea scroll; caret index is throttled (~60ms) and cleared on blur.

## Test plan
- [x] `nx run whiteboard:build` — Next.js compiles and typechecks cleanly
- [x] `nx run whiteboard:lint` / `nx run react-lib:lint` — no new issues
- [ ] Manually verify in two browser tabs on the same room: each user's caret appears at their real typing position and tracks as they type/click/scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)