### PR TITLE
enhancement(hearth): Move Where Is to the top level of the sidebar

### DIFF
--- a/projects/nx-workspace/apps/hearth/src/app/app.consts.ts
+++ b/projects/nx-workspace/apps/hearth/src/app/app.consts.ts
@@ -7,6 +7,7 @@ import {
   PenLine,
   MapPin,
   ChefHat,
+  PackageSearch,
 } from 'lucide-react';
 import { ROUTES } from '../lib/routes';
 
@@ -23,12 +24,12 @@ export const NAV_LINKS = [
       { label: 'Meals', href: ROUTES.MEALS },
     ],
   },
+  { label: 'Where Is', href: ROUTES.WHERE_IS, icon: PackageSearch },
   {
     label: 'Utility',
-    href: ROUTES.WHERE_IS,
+    href: ROUTES.DOCS,
     icon: Wrench,
     children: [
-      { label: 'Where Is', href: ROUTES.WHERE_IS },
       { label: 'Docs', href: ROUTES.DOCS },
       { label: 'Price Tracker', href: ROUTES.PRICE_TRACKER },
     ],


### PR DESCRIPTION
## Summary
- Promoted "Where Is" from a child of the Utility sidebar group to its own top-level nav item, with a `PackageSearch` icon.
- Utility group now defaults to Docs and only contains Docs and Price Tracker as children.

## Test plan
- [ ] Load hearth app and confirm "Where Is" appears as a top-level sidebar item (not nested under Utility).
- [ ] Confirm Utility group still shows Docs and Price Tracker.
- [ ] Confirm sidebar active-state highlighting works correctly for both items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)