### PR TITLE
enhancement(hearth): Move dark mode toggle into topbar user dropdown

### DIFF
--- a/projects/nx-workspace/apps/hearth/src/app/components/Sidebar.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/components/Sidebar.tsx
@@ -2,26 +2,15 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Moon, Sun } from 'lucide-react';
-import {
-  Sidebar as SharedSidebar,
-  SidebarCTA,
-  useTheme,
-} from '@vigilant-broccoli/react-lib';
+import { Sidebar as SharedSidebar, SidebarCTA } from '@vigilant-broccoli/react-lib';
 import { NAV_LINKS } from '../app.consts';
-import { ROUTES } from '../../lib/routes';
 
-const LIGHT_MODE_LABEL = 'Light mode';
-const DARK_MODE_LABEL = 'Dark mode';
-const DARK = 'dark';
 const SIDEBAR_POSITION = 'fixed top-0 left-0 bottom-0 z-30';
 
 export default function Sidebar() {
   const pathname = usePathname();
-  const { appearance, toggleTheme } = useTheme();
-  const isDark = appearance === DARK;
 
-  const navItems: SidebarCTA[] = NAV_LINKS.map(
+  const items: SidebarCTA[] = NAV_LINKS.map(
     ({ label, href, icon, children }) => ({
       label,
       href,
@@ -36,22 +25,6 @@ export default function Sidebar() {
       })),
     }),
   );
-
-  const themeItem: SidebarCTA = {
-    label: isDark ? LIGHT_MODE_LABEL : DARK_MODE_LABEL,
-    icon: isDark ? Sun : Moon,
-    onClick: toggleTheme,
-  };
-
-  const settingsIdx = navItems.findIndex(i => i.href === ROUTES.SETTINGS);
-  const items =
-    settingsIdx >= 0
-      ? [
-          ...navItems.slice(0, settingsIdx),
-          themeItem,
-          ...navItems.slice(settingsIdx),
-        ]
-      : [...navItems, themeItem];
 
   return (
     <SharedSidebar

--- a/projects/nx-workspace/apps/hearth/src/app/components/Topbar.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/components/Topbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { DropdownMenu } from '@radix-ui/themes';
-import { Home } from 'lucide-react';
+import { Home, Moon, Sun } from 'lucide-react';
 import { supabase } from '../../../libs/supabase';
 import { useHome } from '../providers/home-provider';
 import { useAuth } from '../providers/auth-provider';
@@ -11,13 +11,21 @@ import {
   Select,
   UserAvatar,
   USER_AVATAR_VARIANT,
+  useTheme,
 } from '@vigilant-broccoli/react-lib';
+
+const LIGHT_MODE_LABEL = 'Light mode';
+const DARK_MODE_LABEL = 'Dark mode';
+const DARK = 'dark';
 
 export default function Topbar() {
   const { homes, selectedHomeId, setSelectedHomeId } = useHome();
   const session = useAuth();
+  const { appearance, toggleTheme } = useTheme();
   if (!session?.user.email) return null;
   const email = session.user.email;
+  const isDark = appearance === DARK;
+  const ThemeIcon = isDark ? Sun : Moon;
 
   return (
     <header className="fixed top-0 left-0 right-0 z-20 flex items-center justify-end gap-3 px-6 py-3 border-b border-gray-200 bg-white">
@@ -49,6 +57,17 @@ export default function Topbar() {
           <DropdownMenu.Separator />
           <DropdownMenu.Item asChild>
             <Link href={ROUTES.USER_SETTINGS}>User Settings</Link>
+          </DropdownMenu.Item>
+          <DropdownMenu.Separator />
+          <DropdownMenu.Item
+            className="cursor-pointer flex items-center gap-2"
+            onSelect={event => {
+              event.preventDefault();
+              toggleTheme();
+            }}
+          >
+            <ThemeIcon size={14} />
+            {isDark ? LIGHT_MODE_LABEL : DARK_MODE_LABEL}
           </DropdownMenu.Item>
           <DropdownMenu.Separator />
           <DropdownMenu.Item


### PR DESCRIPTION
## Summary
- Removed the dark mode toggle from the sidebar (`Sidebar.tsx`).
- Added it as an item in the user-avatar dropdown menu in `Topbar.tsx`, separated by dividers to match the existing "User Settings" / "Sign out" sections.
- Toggling the theme keeps the dropdown open (`event.preventDefault()` in `onSelect`) instead of closing it on click.

## Test plan
- [ ] Load hearth app, confirm sidebar no longer shows a dark mode toggle item.
- [ ] Open the user dropdown (top right avatar), confirm "Light mode"/"Dark mode" item appears between "User Settings" and "Sign out", each separated by a divider.
- [ ] Click the theme toggle and confirm the dropdown stays open and the theme switches (icon/label update accordingly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)