### PR TITLE
feat(hearth): Add a dev-only Dev Features dropdown to the sidebar

### DIFF
--- a/projects/nx-workspace/apps/hearth/src/app/app.consts.ts
+++ b/projects/nx-workspace/apps/hearth/src/app/app.consts.ts
@@ -1,3 +1,4 @@
+import { ComponentType } from 'react';
 import {
   Calendar,
   Wrench,
@@ -8,44 +9,62 @@ import {
   MapPin,
   ChefHat,
   PackageSearch,
+  FlaskConical,
 } from 'lucide-react';
 import { ROUTES } from '../lib/routes';
 
-export const NAV_LINKS = [
-  {
-    label: 'Calendar',
-    href: ROUTES.CALENDAR,
-    icon: Calendar,
-    children: [
-      { label: 'Overall Calendar', href: ROUTES.OVERALL_CALENDAR },
-      { label: 'Resources', href: ROUTES.RESOURCES },
-      { label: 'Leisure', href: ROUTES.LEISURE },
-      { label: 'Projects', href: ROUTES.PROJECTS },
-      { label: 'Meals', href: ROUTES.MEALS },
-    ],
-  },
+export type NavLink = {
+  label: string;
+  href?: string;
+  icon?: ComponentType<{ size?: number | string }>;
+  children?: NavLink[];
+};
+
+const IS_DEV = process.env.NODE_ENV !== 'production';
+
+const DEV_FEATURES_LINK: NavLink = {
+  label: 'Dev Features',
+  icon: FlaskConical,
+  children: [
+    { label: 'Chores', href: ROUTES.CHORES, icon: ListTodo },
+    { label: 'Food Planner', href: ROUTES.FOOD_PLANNER, icon: ChefHat },
+    {
+      label: 'Lists',
+      href: ROUTES.MASTER_LIST,
+      icon: LayoutList,
+      children: [
+        { label: 'Master List', href: ROUTES.MASTER_LIST },
+        { label: 'Household Rules', href: ROUTES.HOUSEHOLD_RULES },
+      ],
+    },
+    {
+      label: 'Utility',
+      href: ROUTES.DOCS,
+      icon: Wrench,
+      children: [
+        { label: 'Docs', href: ROUTES.DOCS },
+        { label: 'Price Tracker', href: ROUTES.PRICE_TRACKER },
+      ],
+    },
+    {
+      label: 'Calendar',
+      href: ROUTES.CALENDAR,
+      icon: Calendar,
+      children: [
+        { label: 'Overall Calendar', href: ROUTES.OVERALL_CALENDAR },
+        { label: 'Resources', href: ROUTES.RESOURCES },
+        { label: 'Leisure', href: ROUTES.LEISURE },
+        { label: 'Projects', href: ROUTES.PROJECTS },
+        { label: 'Meals', href: ROUTES.MEALS },
+      ],
+    },
+  ],
+};
+
+export const NAV_LINKS: NavLink[] = [
   { label: 'Where Is', href: ROUTES.WHERE_IS, icon: PackageSearch },
-  {
-    label: 'Utility',
-    href: ROUTES.DOCS,
-    icon: Wrench,
-    children: [
-      { label: 'Docs', href: ROUTES.DOCS },
-      { label: 'Price Tracker', href: ROUTES.PRICE_TRACKER },
-    ],
-  },
-  {
-    label: 'Lists',
-    href: ROUTES.MASTER_LIST,
-    icon: LayoutList,
-    children: [
-      { label: 'Master List', href: ROUTES.MASTER_LIST },
-      { label: 'Household Rules', href: ROUTES.HOUSEHOLD_RULES },
-    ],
-  },
-  { label: 'Food Planner', href: ROUTES.FOOD_PLANNER, icon: ChefHat },
+  ...(IS_DEV ? [DEV_FEATURES_LINK] : []),
   { label: 'Find Members', href: ROUTES.LOCATOR, icon: MapPin },
   { label: 'Whiteboard', href: ROUTES.WHITEBOARD, icon: PenLine },
-  { label: 'Chores', href: ROUTES.CHORES, icon: ListTodo },
   { label: 'Settings', href: ROUTES.SETTINGS, icon: Settings },
 ];

--- a/projects/nx-workspace/apps/hearth/src/app/components/Navbar.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/components/Navbar.tsx
@@ -7,11 +7,15 @@ import { Menu, X } from 'lucide-react';
 import { useState } from 'react';
 import { supabase } from '../../../libs/supabase';
 import { ROUTES } from '../../lib/routes';
-import { NAV_LINKS } from '../app.consts';
+import { NAV_LINKS, NavLink } from '../app.consts';
+
+const isLinkWithHref = (link: NavLink): link is NavLink & { href: string } =>
+  Boolean(link.href);
 
 export default function Navbar() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
+  const navLinks = NAV_LINKS.filter(isLinkWithHref);
 
   return (
     <nav className="border-b border-gray-200">
@@ -21,7 +25,7 @@ export default function Navbar() {
             Hearth
           </Link>
           <div className="hidden sm:flex items-center gap-4">
-            {NAV_LINKS.map(({ label, href }) => (
+            {navLinks.map(({ label, href }) => (
               <Link
                 key={href}
                 href={href}
@@ -60,7 +64,7 @@ export default function Navbar() {
 
       {open && (
         <div className="sm:hidden flex flex-col px-6 pb-4 gap-3">
-          {NAV_LINKS.map(({ label, href }) => (
+          {navLinks.map(({ label, href }) => (
             <Link
               key={href}
               href={href}

--- a/projects/nx-workspace/apps/hearth/src/app/components/Sidebar.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/components/Sidebar.tsx
@@ -3,27 +3,27 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Sidebar as SharedSidebar, SidebarCTA } from '@vigilant-broccoli/react-lib';
-import { NAV_LINKS } from '../app.consts';
+import { NAV_LINKS, NavLink } from '../app.consts';
 
 const SIDEBAR_POSITION = 'fixed top-0 left-0 bottom-0 z-30';
+
+const isLinkActive = (link: NavLink, pathname: string): boolean =>
+  (link.href ? pathname.startsWith(link.href) : false) ||
+  (link.children?.some(child => isLinkActive(child, pathname)) ?? false);
+
+const toSidebarCTA = (link: NavLink, pathname: string): SidebarCTA => ({
+  label: link.label,
+  href: link.href,
+  icon: link.icon,
+  isActive: isLinkActive(link, pathname),
+  children: link.children?.map(child => toSidebarCTA(child, pathname)),
+});
 
 export default function Sidebar() {
   const pathname = usePathname();
 
-  const items: SidebarCTA[] = NAV_LINKS.map(
-    ({ label, href, icon, children }) => ({
-      label,
-      href,
-      icon,
-      isActive:
-        pathname.startsWith(href) ||
-        (children?.some(c => pathname.startsWith(c.href)) ?? false),
-      children: children?.map(c => ({
-        label: c.label,
-        href: c.href,
-        isActive: pathname.startsWith(c.href),
-      })),
-    }),
+  const items: SidebarCTA[] = NAV_LINKS.map(link =>
+    toSidebarCTA(link, pathname),
   );
 
   return (

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/components/Sidebar.tsx
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/components/Sidebar.tsx
@@ -350,6 +350,7 @@ const NestedItem = ({
   LinkComponent,
   onToggle,
 }: NestedItemProps) => {
+  const [openChildId, setOpenChildId] = useState<string | null>(null);
   const Icon = item.icon;
   const labelClass = cn(
     'whitespace-nowrap overflow-hidden text-left transition-all duration-150',
@@ -390,15 +391,32 @@ const NestedItem = ({
       >
         <div className="overflow-hidden">
           <div className="flex flex-col gap-1 mt-1 ml-3 pb-1">
-            {item.children?.map((child, idx) => (
-              <ItemRow
-                key={child.href ?? `${child.label}-${idx}`}
-                item={child}
-                labelClassName="opacity-100"
-                LinkComponent={LinkComponent}
-                className="px-3 py-1.5"
-              />
-            ))}
+            {item.children?.map((child, idx) => {
+              const childKey = child.href ?? `${child.label}-${idx}`;
+              if (child.children && child.children.length > 0) {
+                return (
+                  <NestedItem
+                    key={childKey}
+                    item={child}
+                    isOpen={openChildId === childKey}
+                    expandable={expandable}
+                    LinkComponent={LinkComponent}
+                    onToggle={() =>
+                      setOpenChildId(openChildId === childKey ? null : childKey)
+                    }
+                  />
+                );
+              }
+              return (
+                <ItemRow
+                  key={childKey}
+                  item={child}
+                  labelClassName="opacity-100"
+                  LinkComponent={LinkComponent}
+                  className="px-3 py-1.5"
+                />
+              );
+            })}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add a new "Dev Features" collapsible section (flask icon) to the hearth sidebar, nesting Chores, Food Planner, Lists, Utility, and Calendar under it (each keeping their existing sub-items).
- Gate the section behind `process.env.NODE_ENV !== 'production'`, the same dev-only pattern already used by `api/dev/seed` and `api/dev/clear`, so it's excluded from production builds entirely rather than just visually hidden.
- Make the shared `react-lib` `Sidebar` component's nested-dropdown rendering recursive so a dropdown item can itself contain dropdown items (needed since Calendar/Lists/Utility already had their own children).
- Update hearth's `Sidebar.tsx` active-state logic to match, and fix the (currently unused) `Navbar.tsx` component, which assumed every nav entry has an `href`, to filter out group entries like the hrefless `Dev Features`.

## Test plan
- [x] `tsc --noEmit` on `apps/hearth` and `libs/@vigilant-broccoli/react-lib` — clean.
- [x] `eslint` on the changed files — no new errors (one pre-existing complexity warning on `Sidebar.tsx` unchanged).
- [x] Verified in the browser (dev mode): "Dev Features" opens to reveal Chores, Food Planner, Lists, Utility, Calendar; opening "Calendar" reveals its own sub-items (3 levels deep); navigating to `/resources` correctly highlights "Dev Features" as active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)