### PR TITLE
enhancement(hearth): Mobile hamburger menu opens sidebar as a drawer

### DIFF
--- a/projects/nx-workspace/apps/hearth/src/app/components/AppLayout.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/components/AppLayout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useAuth } from '../providers/auth-provider';
 import { ROUTES } from '../../lib/routes';
@@ -13,6 +13,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const session = useAuth();
   const router = useRouter();
   const pathname = usePathname();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const isPublic = PUBLIC_ROUTES.some(r => pathname.startsWith(r));
 
@@ -35,9 +36,12 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
 
   return (
     <>
-      <Topbar />
-      <Sidebar />
-      <div className="pt-[49px] pl-14">{children}</div>
+      <Topbar onMenuClick={() => setSidebarOpen(open => !open)} />
+      <Sidebar
+        mobileOpen={sidebarOpen}
+        onMobileClose={() => setSidebarOpen(false)}
+      />
+      <div className="pt-[49px] pl-0 md:pl-14">{children}</div>
     </>
   );
 }

--- a/projects/nx-workspace/apps/hearth/src/app/components/Sidebar.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/components/Sidebar.tsx
@@ -19,7 +19,12 @@ const toSidebarCTA = (link: NavLink, pathname: string): SidebarCTA => ({
   children: link.children?.map(child => toSidebarCTA(child, pathname)),
 });
 
-export default function Sidebar() {
+type SidebarProps = {
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
+};
+
+export default function Sidebar({ mobileOpen, onMobileClose }: SidebarProps) {
   const pathname = usePathname();
 
   const items: SidebarCTA[] = NAV_LINKS.map(link =>
@@ -32,6 +37,8 @@ export default function Sidebar() {
       LinkComponent={Link}
       searchable
       className={SIDEBAR_POSITION}
+      mobileOpen={mobileOpen}
+      onMobileClose={onMobileClose}
     />
   );
 }

--- a/projects/nx-workspace/apps/hearth/src/app/components/Topbar.tsx
+++ b/projects/nx-workspace/apps/hearth/src/app/components/Topbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { DropdownMenu } from '@radix-ui/themes';
-import { Home, Moon, Sun } from 'lucide-react';
+import { Home, Menu, Moon, Sun } from 'lucide-react';
 import { supabase } from '../../../libs/supabase';
 import { useHome } from '../providers/home-provider';
 import { useAuth } from '../providers/auth-provider';
@@ -18,7 +18,11 @@ const LIGHT_MODE_LABEL = 'Light mode';
 const DARK_MODE_LABEL = 'Dark mode';
 const DARK = 'dark';
 
-export default function Topbar() {
+type TopbarProps = {
+  onMenuClick: () => void;
+};
+
+export default function Topbar({ onMenuClick }: TopbarProps) {
   const { homes, selectedHomeId, setSelectedHomeId } = useHome();
   const session = useAuth();
   const { appearance, toggleTheme } = useTheme();
@@ -28,57 +32,68 @@ export default function Topbar() {
   const ThemeIcon = isDark ? Sun : Moon;
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-20 flex items-center justify-end gap-3 px-6 py-3 border-b border-gray-200 bg-white">
-      {homes.length > 0 && (
-        <div className="flex items-center gap-1.5 text-gray-500">
-          <Home size={14} />
-          <Select
-            selectedOption={homes.find(h => h.id === selectedHomeId)}
-            setValue={home => setSelectedHomeId(home.id)}
-            options={homes}
-            optionIdenfifier="id"
-            optionDisplayKey="name"
-          />
-        </div>
-      )}
+    <header className="fixed top-0 left-0 right-0 z-20 flex items-center justify-between md:justify-end gap-3 px-6 py-3 border-b border-gray-200 bg-white">
+      <button
+        type="button"
+        aria-label="Open menu"
+        onClick={onMenuClick}
+        className="md:hidden cursor-pointer rounded-md p-1 text-gray-500 hover:text-black hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400"
+      >
+        <Menu size={20} />
+      </button>
 
-      <DropdownMenu.Root>
-        <DropdownMenu.Trigger>
-          <button className="cursor-pointer rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400">
-            <UserAvatar name={email} variant={USER_AVATAR_VARIANT.INITIALS} />
-          </button>
-        </DropdownMenu.Trigger>
-        <DropdownMenu.Content align="end" size="1">
-          <div className="px-2 py-1.5">
-            <p className="text-xs text-gray-500 truncate max-w-[180px]">
-              {email}
-            </p>
+      <div className="flex items-center gap-3">
+        {homes.length > 0 && (
+          <div className="flex items-center gap-1.5 text-gray-500">
+            <Home size={14} />
+            <Select
+              selectedOption={homes.find(h => h.id === selectedHomeId)}
+              setValue={home => setSelectedHomeId(home.id)}
+              options={homes}
+              optionIdenfifier="id"
+              optionDisplayKey="name"
+            />
           </div>
-          <DropdownMenu.Separator />
-          <DropdownMenu.Item asChild>
-            <Link href={ROUTES.USER_SETTINGS}>User Settings</Link>
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator />
-          <DropdownMenu.Item
-            className="cursor-pointer flex items-center gap-2"
-            onSelect={event => {
-              event.preventDefault();
-              toggleTheme();
-            }}
-          >
-            <ThemeIcon size={14} />
-            {isDark ? LIGHT_MODE_LABEL : DARK_MODE_LABEL}
-          </DropdownMenu.Item>
-          <DropdownMenu.Separator />
-          <DropdownMenu.Item
-            color="red"
-            className="cursor-pointer"
-            onClick={() => supabase.auth.signOut()}
-          >
-            Sign out
-          </DropdownMenu.Item>
-        </DropdownMenu.Content>
-      </DropdownMenu.Root>
+        )}
+
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger>
+            <button className="cursor-pointer rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400">
+              <UserAvatar name={email} variant={USER_AVATAR_VARIANT.INITIALS} />
+            </button>
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content align="end" size="1">
+            <div className="px-2 py-1.5">
+              <p className="text-xs text-gray-500 truncate max-w-[180px]">
+                {email}
+              </p>
+            </div>
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item asChild>
+              <Link href={ROUTES.USER_SETTINGS}>User Settings</Link>
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item
+              className="cursor-pointer flex items-center gap-2"
+              onSelect={event => {
+                event.preventDefault();
+                toggleTheme();
+              }}
+            >
+              <ThemeIcon size={14} />
+              {isDark ? LIGHT_MODE_LABEL : DARK_MODE_LABEL}
+            </DropdownMenu.Item>
+            <DropdownMenu.Separator />
+            <DropdownMenu.Item
+              color="red"
+              className="cursor-pointer"
+              onClick={() => supabase.auth.signOut()}
+            >
+              Sign out
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
+      </div>
     </header>
   );
 }

--- a/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/components/Sidebar.tsx
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/react-lib/src/components/Sidebar.tsx
@@ -35,6 +35,8 @@ export type SidebarProps = {
   footer?: ReactNode;
   LinkComponent?: LinkComponent;
   className?: string;
+  mobileOpen?: boolean;
+  onMobileClose?: () => void;
 };
 
 const ICON_SIZE = 18;
@@ -42,6 +44,15 @@ const CHEVRON_SIZE = 14;
 const BRANDING_HEIGHT = 'h-[49px]';
 const COLLAPSED_WIDTH = 'w-14';
 const EXPANDED_WIDTH = 'hover:w-48';
+
+const MOBILE_WIDTH = 'max-md:w-64';
+const MOBILE_OPEN_TRANSFORM = 'max-md:translate-x-0';
+const MOBILE_CLOSED_TRANSFORM = 'max-md:-translate-x-full';
+const MD_VISIBLE_TRANSFORM = 'md:translate-x-0';
+const MD_COLLAPSED_WIDTH = 'md:w-14';
+const MD_EXPANDED_WIDTH = 'md:hover:w-48';
+const MOBILE_BACKDROP =
+  'fixed inset-0 z-20 bg-black/50 md:hidden';
 
 const BORDER_COLOR = 'border-gray-200 dark:border-gray-800';
 const SURFACE_BG = 'bg-white dark:bg-gray-950';
@@ -161,6 +172,8 @@ export const Sidebar = ({
   footer,
   LinkComponent,
   className,
+  mobileOpen,
+  onMobileClose,
 }: SidebarProps) => {
   const [openId, setOpenId] = useState<string | null>(null);
   const [query, setQuery] = useState('');
@@ -171,110 +184,136 @@ export const Sidebar = ({
       ? flat.filter(p => p.label.toLowerCase().includes(query.toLowerCase()))
       : null;
 
-  const widthClass = expandable
-    ? `${COLLAPSED_WIDTH} ${EXPANDED_WIDTH}`
-    : COLLAPSED_WIDTH;
-  const collapsibleLabelClass = labelClassFor(expandable);
-  const itemLabelClass = expandable ? LABEL_COLLAPSIBLE : LABEL_VISIBLE;
+  const isMobileAware = mobileOpen !== undefined;
+  const forceExpanded = isMobileAware && mobileOpen;
+  const widthClass = isMobileAware
+    ? cn(
+        MOBILE_WIDTH,
+        mobileOpen ? MOBILE_OPEN_TRANSFORM : MOBILE_CLOSED_TRANSFORM,
+        MD_VISIBLE_TRANSFORM,
+        MD_COLLAPSED_WIDTH,
+        expandable && MD_EXPANDED_WIDTH,
+      )
+    : cn(COLLAPSED_WIDTH, expandable && EXPANDED_WIDTH);
+  const collapsibleLabelClass = forceExpanded
+    ? LABEL_VISIBLE
+    : labelClassFor(expandable);
+  const itemLabelClass = forceExpanded
+    ? LABEL_VISIBLE
+    : expandable
+      ? LABEL_COLLAPSIBLE
+      : LABEL_VISIBLE;
 
   const borderClass = `${side === 'right' ? 'border-l' : 'border-r'} ${BORDER_COLOR}`;
   const listJustify =
     align === 'space-evenly' ? 'justify-evenly' : 'justify-start';
 
   return (
-    <aside
-      className={cn(
-        'group/sidebar shrink-0 flex flex-col overflow-hidden transition-all duration-200',
-        SURFACE_BG,
-        widthClass,
-        borderClass,
-        className,
+    <>
+      {isMobileAware && mobileOpen && (
+        <div className={MOBILE_BACKDROP} onClick={onMobileClose} />
       )}
-      onMouseLeave={() => {
-        setOpenId(null);
-        setQuery('');
-      }}
-    >
-      {branding && (
-        <BrandingHeader
-          branding={branding}
-          LinkComponent={LinkComponent}
-          expandable={expandable}
-        />
-      )}
-
-      <div
+      <aside
         className={cn(
-          'flex flex-col flex-1 gap-1 px-2 py-4 overflow-y-auto overflow-x-hidden',
-          listJustify,
+          'group/sidebar shrink-0 flex flex-col overflow-hidden transition-all duration-200',
+          SURFACE_BG,
+          widthClass,
+          borderClass,
+          className,
         )}
+        onMouseLeave={() => {
+          setOpenId(null);
+          setQuery('');
+        }}
       >
-        {searchable && (
-          <div className={cn('flex items-center gap-3 px-2 py-2 rounded-md', ROW_INACTIVE)}>
-            <span className="shrink-0">
-              <Search size={ICON_SIZE} />
-            </span>
-            <input
-              type="text"
-              value={query}
-              onChange={e => setQuery(e.target.value)}
-              placeholder="Search..."
-              className={cn(
-                'transition-all duration-150 text-sm bg-transparent outline-none placeholder-gray-400 dark:placeholder-gray-500 dark:text-white min-w-0',
-                collapsibleLabelClass,
-              )}
-            />
-          </div>
+        {branding && (
+          <BrandingHeader
+            branding={branding}
+            LinkComponent={LinkComponent}
+            expandable={expandable}
+            forceExpanded={forceExpanded}
+          />
         )}
 
-        {results ? (
-          results.length > 0 ? (
-            results.map((item, idx) => (
-              <ItemRow
-                key={`${item.label}-${idx}`}
-                item={item}
-                labelClassName={LABEL_VISIBLE}
-                LinkComponent={LinkComponent}
-                onClickExtra={() => setQuery('')}
+        <div
+          className={cn(
+            'flex flex-col flex-1 gap-1 px-2 py-4 overflow-y-auto overflow-x-hidden',
+            listJustify,
+          )}
+        >
+          {searchable && (
+            <div className={cn('flex items-center gap-3 px-2 py-2 rounded-md', ROW_INACTIVE)}>
+              <span className="shrink-0">
+                <Search size={ICON_SIZE} />
+              </span>
+              <input
+                type="text"
+                value={query}
+                onChange={e => setQuery(e.target.value)}
+                placeholder="Search..."
+                className={cn(
+                  'transition-all duration-150 text-sm bg-transparent outline-none placeholder-gray-400 dark:placeholder-gray-500 dark:text-white min-w-0',
+                  collapsibleLabelClass,
+                )}
               />
-            ))
+            </div>
+          )}
+
+          {results ? (
+            results.length > 0 ? (
+              results.map((item, idx) => (
+                <ItemRow
+                  key={`${item.label}-${idx}`}
+                  item={item}
+                  labelClassName={LABEL_VISIBLE}
+                  LinkComponent={LinkComponent}
+                  onClickExtra={() => {
+                    setQuery('');
+                    onMobileClose?.();
+                  }}
+                />
+              ))
+            ) : (
+              <span className="text-xs text-gray-400 dark:text-gray-500 px-3 py-2">
+                No results
+              </span>
+            )
           ) : (
-            <span className="text-xs text-gray-400 dark:text-gray-500 px-3 py-2">
-              No results
-            </span>
-          )
-        ) : (
-          items.map((item, idx) => {
-            const itemKey = item.href ?? `${item.label}-${idx}`;
-            if (item.children && item.children.length > 0) {
-              const isOpen = openId === itemKey;
+            items.map((item, idx) => {
+              const itemKey = item.href ?? `${item.label}-${idx}`;
+              if (item.children && item.children.length > 0) {
+                const isOpen = openId === itemKey;
+                return (
+                  <NestedItem
+                    key={itemKey}
+                    item={item}
+                    isOpen={isOpen}
+                    expandable={expandable}
+                    LinkComponent={LinkComponent}
+                    onToggle={() => setOpenId(isOpen ? null : itemKey)}
+                    onNavigate={onMobileClose}
+                    forceExpanded={forceExpanded}
+                  />
+                );
+              }
               return (
-                <NestedItem
+                <ItemRow
                   key={itemKey}
                   item={item}
-                  isOpen={isOpen}
-                  expandable={expandable}
+                  labelClassName={itemLabelClass}
                   LinkComponent={LinkComponent}
-                  onToggle={() => setOpenId(isOpen ? null : itemKey)}
+                  onClickExtra={onMobileClose}
                 />
               );
-            }
-            return (
-              <ItemRow
-                key={itemKey}
-                item={item}
-                labelClassName={itemLabelClass}
-                LinkComponent={LinkComponent}
-              />
-            );
-          })
-        )}
-      </div>
+            })
+          )}
+        </div>
 
-      {footer && (
-        <div className={cn('shrink-0 border-t', BORDER_COLOR)}>{footer}</div>
-      )}
-    </aside>
+        {footer && (
+          <div className={cn('shrink-0 border-t', BORDER_COLOR)}>{footer}</div>
+        )}
+      </aside>
+    </>
   );
 };
 
@@ -282,12 +321,14 @@ type BrandingHeaderProps = {
   branding: SidebarBranding;
   LinkComponent?: LinkComponent;
   expandable: boolean;
+  forceExpanded?: boolean;
 };
 
 const BrandingHeader = ({
   branding,
   LinkComponent,
   expandable,
+  forceExpanded = false,
 }: BrandingHeaderProps) => {
   const Icon = branding.icon;
   const visual =
@@ -300,16 +341,20 @@ const BrandingHeader = ({
 
   const labelClass = cn(
     'overflow-hidden font-semibold text-sm whitespace-nowrap transition-all duration-150',
-    expandable
-      ? 'w-0 opacity-0 group-hover/sidebar:w-auto group-hover/sidebar:opacity-100'
-      : 'opacity-100',
+    forceExpanded
+      ? 'opacity-100'
+      : expandable
+        ? 'w-0 opacity-0 group-hover/sidebar:w-auto group-hover/sidebar:opacity-100'
+        : 'opacity-100',
   );
 
   const containerClass = cn(
     'flex items-center border-b shrink-0 gap-3 px-3 dark:text-white',
     BRANDING_HEIGHT,
     BORDER_COLOR,
-    expandable && 'justify-center group-hover/sidebar:justify-start',
+    forceExpanded
+      ? 'justify-start'
+      : expandable && 'justify-center group-hover/sidebar:justify-start',
   );
 
   const inner = (
@@ -341,6 +386,8 @@ type NestedItemProps = {
   expandable: boolean;
   LinkComponent?: LinkComponent;
   onToggle: () => void;
+  onNavigate?: () => void;
+  forceExpanded?: boolean;
 };
 
 const NestedItem = ({
@@ -349,16 +396,22 @@ const NestedItem = ({
   expandable,
   LinkComponent,
   onToggle,
+  onNavigate,
+  forceExpanded = false,
 }: NestedItemProps) => {
   const [openChildId, setOpenChildId] = useState<string | null>(null);
   const Icon = item.icon;
   const labelClass = cn(
     'whitespace-nowrap overflow-hidden text-left transition-all duration-150',
-    labelClassFor(expandable),
+    forceExpanded ? LABEL_VISIBLE : labelClassFor(expandable),
   );
   const chevronClass = cn(
     'shrink-0 transition-opacity duration-150',
-    expandable ? 'opacity-0 group-hover/sidebar:opacity-100' : LABEL_HIDDEN,
+    forceExpanded
+      ? 'opacity-100'
+      : expandable
+        ? 'opacity-0 group-hover/sidebar:opacity-100'
+        : LABEL_HIDDEN,
   );
 
   return (
@@ -404,6 +457,8 @@ const NestedItem = ({
                     onToggle={() =>
                       setOpenChildId(openChildId === childKey ? null : childKey)
                     }
+                    onNavigate={onNavigate}
+                    forceExpanded={forceExpanded}
                   />
                 );
               }
@@ -412,6 +467,7 @@ const NestedItem = ({
                   key={childKey}
                   item={child}
                   labelClassName="opacity-100"
+                  onClickExtra={onNavigate}
                   LinkComponent={LinkComponent}
                   className="px-3 py-1.5"
                 />


### PR DESCRIPTION
## Summary
- Added a `Menu` hamburger button to hearth's `Topbar` (visible `md:hidden`) that toggles the sidebar open on mobile.
- Extended the shared `Sidebar` component (`@vigilant-broccoli/react-lib`, also used by `employee-handler-ui` and `vb-manager-next`) with optional `mobileOpen`/`onMobileClose` props — when omitted, behavior is unchanged for those other apps. When passed, the sidebar becomes a `max-md:` off-canvas drawer with a `md:hidden` backdrop, sliding in via `translate-x`, while staying the normal hover-collapsible rail at `md:` and up.
- Fixed label/chevron/search-box visibility inside the open drawer: those elements previously relied on `group-hover/sidebar` (mouse hover) to reveal, which never fires on a touch tap. Added a `forceExpanded` flag (true while the mobile drawer is open) that overrides the hover-based classes so text is visible immediately, threaded through top-level items, nested groups (including recursive sub-groups), the search input, and branding.
- Clicking a nav link or the backdrop closes the drawer; hearth's content padding is now responsive (`pl-0 md:pl-14`) since the drawer no longer reserves layout space on mobile.

## Test plan
- [x] `nx lint` and `tsc --noEmit` pass clean on both `hearth` and `react-lib` with no new errors/warnings.
- [x] Verified live against a running hearth dev server (via a side-by-side mobile/desktop iframe harness): hamburger toggles the drawer, labels/nested groups/search box are all visible on open, clicking a leaf link navigates and auto-closes the drawer, desktop layout and hover-collapse behavior unaffected.
- [ ] Spot-check `employee-handler-ui` and `vb-manager-next` sidebars still render unchanged (they don't pass the new props).

🤖 Generated with [Claude Code](https://claude.com/claude-code)