### PR TITLE
ci(github-actions): Guard cron-backup run steps with set -euo pipefail

### DIFF
--- a/.github/workflows/cron-backup.yml
+++ b/.github/workflows/cron-backup.yml
@@ -29,12 +29,14 @@ jobs:
 
       - name: Upload backup to GCS
         run: |
+          set -euo pipefail
           TIMESTAMP=$(date -u +%Y-%m-%d)
           curl -sL -o vigilant-broccoli.zip https://github.com/iamharryliu/vigilant-broccoli/archive/refs/heads/main.zip
           gsutil cp vigilant-broccoli.zip gs://vigilant-broccoli-backup/repo-backup-$TIMESTAMP.zip
 
       - name: Cleanup old backups
         run: |
+          set -euo pipefail
           MAX_BACKUPS=7
           BACKUPS=$(gsutil ls gs://vigilant-broccoli-backup/repo-backup-*.zip | sort)
           BACKUP_COUNT=$(echo "$BACKUPS" | wc -l)
@@ -72,6 +74,7 @@ jobs:
           OCI_VM_SSH_KEY: ${{ env.OCI_VM_SSH_KEY }}
           GITEA_VM_IP: ${{ env.GITEA_VM_IP }}
         run: |
+          set -euo pipefail
           TIMESTAMP=$(date -u +%Y-%m-%d)
           # Ensure a trailing newline — the stored key lacks one and OpenSSL/libcrypto rejects it.
           { printf '%s' "$OCI_VM_SSH_KEY" | base64 -d; echo; } > ssh_key
@@ -89,6 +92,7 @@ jobs:
 
       - name: Cleanup old backups
         run: |
+          set -euo pipefail
           MAX_BACKUPS=7
           BACKUPS=$(gsutil ls gs://vigilant-broccoli-backup/gitea-backup-*.zip | sort)
           BACKUP_COUNT=$(echo "$BACKUPS" | wc -l)
@@ -122,6 +126,7 @@ jobs:
 
       - name: Install mongodb-database-tools
         run: |
+          set -euo pipefail
           curl -sL -o mongodb-tools.deb https://fastdl.mongodb.org/tools/db/mongodb-database-tools-ubuntu2204-x86_64-100.10.0.deb
           sudo dpkg -i mongodb-tools.deb
 
@@ -130,12 +135,14 @@ jobs:
           MONGODB_URI: ${{ env.MONGODB_URI }}
           MONGODB_DB: vb-manager
         run: |
+          set -euo pipefail
           TIMESTAMP=$(date -u +%Y-%m-%d)
           mongodump --uri="$MONGODB_URI" --db="$MONGODB_DB" --archive="mongodb-$MONGODB_DB.gz" --gzip
           gsutil cp "mongodb-$MONGODB_DB.gz" "gs://vigilant-broccoli-backup/mongodb-backup-$TIMESTAMP.gz"
 
       - name: Cleanup old backups
         run: |
+          set -euo pipefail
           MAX_BACKUPS=7
           BACKUPS=$(gsutil ls gs://vigilant-broccoli-backup/mongodb-backup-*.gz | sort)
           BACKUP_COUNT=$(echo "$BACKUPS" | wc -l)
@@ -169,6 +176,7 @@ jobs:
 
       - name: Install PostgreSQL client
         run: |
+          set -euo pipefail
           sudo sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo gpg --dearmor -o /usr/share/keyrings/postgresql.gpg
           sudo sed -i 's|deb |deb [signed-by=/usr/share/keyrings/postgresql.gpg] |' /etc/apt/sources.list.d/pgdg.list
@@ -179,12 +187,14 @@ jobs:
         env:
           SUPABASE_DB_URL: ${{ env.SUPABASE_DB_URL }}
         run: |
+          set -euo pipefail
           TIMESTAMP=$(date -u +%Y-%m-%d)
           pg_dump "$SUPABASE_DB_URL" --no-owner --no-privileges | gzip > "supabase.sql.gz"
           gsutil cp "supabase.sql.gz" "gs://vigilant-broccoli-backup/supabase-backup-$TIMESTAMP.sql.gz"
 
       - name: Cleanup old backups
         run: |
+          set -euo pipefail
           MAX_BACKUPS=7
           BACKUPS=$(gsutil ls gs://vigilant-broccoli-backup/supabase-backup-*.sql.gz | sort)
           BACKUP_COUNT=$(echo "$BACKUPS" | wc -l)


### PR DESCRIPTION
## Summary
- `backup-supabase`'s `pg_dump "$SUPABASE_DB_URL" | gzip > supabase.sql.gz` step has been silently uploading ~20-byte (empty) backups to GCS every day since 2026-07-30, because `pg_dump` fails (malformed `SUPABASE_DB_URL` secret in Vault) but the step's exit code is only `gzip`'s, which succeeds trivially on empty input.
- These `run:` steps don't set `shell: bash`, so GitHub Actions falls back to the implicit `bash -e {0}` default, which does **not** include `pipefail` — a pipeline's exit status is only the last command's.
- Added `set -euo pipefail` as the first line of all 10 `run:` blocks across the four backup jobs (`backup-vb-repo`, `backup-gitea`, `backup-mongodb`, `backup-supabase`) so any command failing inside a pipe now fails the step loudly instead of silently continuing.
- Note: the underlying `SUPABASE_DB_URL` secret in Vault is still malformed and needs a separate manual fix (pull a fresh connection string from the Supabase dashboard, percent-encode any special characters in the password) — this PR only fixes the workflow so future failures surface instead of being masked.

## Test plan
- [x] `python3`/`yq` validated the workflow YAML is still well-formed after the edits.
- [ ] Manually trigger the workflow (`workflow_dispatch`) after the Vault secret is fixed and confirm `backup-supabase` produces a non-trivial `.sql.gz` and the step fails loudly if `pg_dump` errors again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)