### PR TITLE
feat(vb-manager-next): Add a percent-encoding tool to text-tools

### DIFF
--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/pages/TextToolsPage.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/components/pages/TextToolsPage.tsx
@@ -15,6 +15,7 @@ export const TextToolsPage = () => {
       <FormatBlockStringToSingleStringForm />
       <TextToBase64Form />
       <Base64ToTextForm />
+      <TextToPercentEncodedForm />
       <CharacterCounter />
     </div>
   );
@@ -150,6 +151,22 @@ const Base64ToTextForm = () => {
       initialText={''}
       sampleText={SAMPLE_BASE64}
       conversionFn={EnvUtils.decodeBase64}
+    />
+  );
+};
+
+const SAMPLE_TEXT_FOR_PERCENT_ENCODING = 'p@ss w0rd/#1';
+
+const TextToPercentEncodedForm = () => {
+  return (
+    <ConversionForm
+      copy={{
+        header: 'Text to Percent Encoded (URL Encoding)',
+        placeholder: SAMPLE_TEXT_FOR_PERCENT_ENCODING,
+      }}
+      initialText={''}
+      sampleText={SAMPLE_TEXT_FOR_PERCENT_ENCODING}
+      conversionFn={EnvUtils.encodePercent}
     />
   );
 };

--- a/projects/nx-workspace/libs/@vigilant-broccoli/common-js/src/lib/utils/env.utils.ts
+++ b/projects/nx-workspace/libs/@vigilant-broccoli/common-js/src/lib/utils/env.utils.ts
@@ -95,6 +95,14 @@ function decodeBase64(base64: string): string {
   }
 }
 
+function encodePercent(text: string): string {
+  try {
+    return encodeURIComponent(text);
+  } catch {
+    return '';
+  }
+}
+
 export const EnvUtils = {
   getPrettierJSON,
   getEnvironmentVariablesFromJSON,
@@ -104,4 +112,5 @@ export const EnvUtils = {
   formatBlockStringToSingleLineString,
   encodeBase64,
   decodeBase64,
+  encodePercent,
 };


### PR DESCRIPTION
## Summary
- Added `EnvUtils.encodePercent` (`encodeURIComponent` wrapper) to `@vigilant-broccoli/common-js`, following the same try/catch convention as `decodeBase64`.
- Added a "Text to Percent Encoded (URL Encoding)" card to vb-manager-next's `/text-tools` page, wired the same way as the existing `TextToBase64Form` card.
- Purely additive: no existing `EnvUtils` function signature changed, and `common-js` has no `publish-package` target, so this stays internal to the nx workspace (not shipped to npm).

## Test plan
- [x] `nx run @vigilant-broccoli/common-js:typecheck` passes.
- [x] `nx run vb-manager-next:build` succeeds, including the `/text-tools` route.
- [ ] Manually load `/text-tools` and confirm the new card encodes special characters (e.g. `p@ss w0rd/#1`) as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)