### PR TITLE
fix(github-actions): Pin pg_dump to the installed v17 binary in cron-backup

### DIFF
--- a/.github/workflows/cron-backup.yml
+++ b/.github/workflows/cron-backup.yml
@@ -189,7 +189,8 @@ jobs:
         run: |
           set -euo pipefail
           TIMESTAMP=$(date -u +%Y-%m-%d)
-          pg_dump "$SUPABASE_DB_URL" --no-owner --no-privileges | gzip > "supabase.sql.gz"
+          # The runner image ships an older postgresql-client on PATH; call the v17 binary directly.
+          /usr/lib/postgresql/17/bin/pg_dump "$SUPABASE_DB_URL" --no-owner --no-privileges | gzip > "supabase.sql.gz"
           gsutil cp "supabase.sql.gz" "gs://vigilant-broccoli-backup/supabase-backup-$TIMESTAMP.sql.gz"
 
       - name: Cleanup old backups


### PR DESCRIPTION
## Summary
- The pipefail guard from #314 immediately caught a real failure on the first run after merge: `pg_dump: error: aborting because of server version mismatch` — `server version: 17.6; pg_dump version: 16.14`.
- Root cause: the `ubuntu-24.04` GitHub-hosted runner image already ships `postgresql-client-16` (also a PGDG package) on `PATH`. The workflow's `apt-get install -y postgresql-client-17` step installs v17 successfully (`update-alternatives` even confirms it), but the bare `pg_dump` command still resolves to the pre-existing v16 binary, which refuses to dump from a server newer than itself.
- Fix: invoke `/usr/lib/postgresql/17/bin/pg_dump` directly instead of relying on `PATH` resolution.

## Test plan
- [x] YAML re-validated (`js-yaml`) after the edit.
- [ ] Trigger the workflow (`workflow_dispatch`) and confirm `backup-supabase` produces a non-trivial `.sql.gz` in GCS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)