### PR TITLE
enhancement(agent-sandbox): Salvage partial work when an agent solve run fails

### DIFF
--- a/infrastructure/agent-sandbox/solve-todo-runner.sh
+++ b/infrastructure/agent-sandbox/solve-todo-runner.sh
@@ -54,6 +54,61 @@ git checkout -b "$BRANCH"
 BASE_SHA=$(git rev-parse HEAD)
 rm -f "$META_FILE"
 
+salvage_on_failure() {
+  local exit_code=$?
+  trap - EXIT
+  set +e
+  [ "$exit_code" -eq 0 ] && exit 0
+
+  echo "Runner exited with status $exit_code — checking for salvageable work on $BRANCH" >&2
+  git checkout "$BRANCH" >/dev/null 2>&1
+
+  if [ -z "$(git status --porcelain)" ]; then
+    echo "No uncommitted changes to salvage." >&2
+    exit "$exit_code"
+  fi
+
+  if [ "$MODE" = id ]; then
+    SALVAGE_TITLE="[WIP] Resolve TODO ${ID} (agent run incomplete)"
+  else
+    SALVAGE_TITLE="[WIP] $(printf '%s' "$TASK" | tr '\n' ' ' | cut -c1-80) (agent run incomplete)"
+  fi
+
+  git add -A
+  # --no-verify: a WIP salvage commit must not be blocked by lint/format hooks —
+  # the goal is to preserve an unfinished diff, not to ship clean code.
+  git commit --no-verify -m "wip: Save partial progress from an incomplete agent run." -m "$FALLBACK_TRAILER"
+
+  if ! git push -u origin "$BRANCH"; then
+    echo "Failed to push salvage branch $BRANCH — partial work could not be recovered." >&2
+    exit "$exit_code"
+  fi
+
+  SALVAGE_BODY=$(cat <<BODY
+## Summary
+
+This agent run did not finish (exited with status ${exit_code}). This draft PR captures its partial, uncommitted work so it isn't lost.
+
+Original task:
+
+${TASK}
+
+To continue, run: \`pnpm agentic:pr:update <PR#> "finish the task"\`
+
+$PR_FOOTER
+BODY
+)
+
+  if PR_URL=$(gh pr create --draft --title "$SALVAGE_TITLE" --body "$SALVAGE_BODY" 2>&1); then
+    echo "Salvaged partial work: $PR_URL" >&2
+  else
+    echo "Pushed salvage branch $BRANCH but failed to open a PR — open one manually." >&2
+  fi
+
+  exit "$exit_code"
+}
+trap salvage_on_failure EXIT
+
 PROMPT=$(cat <<EOF
 You are running non-interactively in a fresh clone of vigilant-broccoli, on a dedicated branch. $INTRO
 

--- a/infrastructure/agent-sandbox/solve-todo.sh
+++ b/infrastructure/agent-sandbox/solve-todo.sh
@@ -52,7 +52,10 @@ if [ -z "${GH_TOKEN:-}" ]; then
 fi
 
 if [ -n "$PROMPT" ]; then
+  LOG_DIR=$(mktemp -d /tmp/vb-solve.XXXXXX)
+  LOG_FILE="$LOG_DIR/solve-prompt.log"
   echo "Solving free-text task (model: $MODEL): $PROMPT"
+  echo "Log: $LOG_FILE"
   docker run --rm --init --name "vb-solve-prompt-$(date +%s)" \
     --cap-add NET_ADMIN --cap-add NET_RAW \
     -e CLAUDE_CODE_OAUTH_TOKEN \
@@ -62,8 +65,9 @@ if [ -n "$PROMPT" ]; then
     -e SANDBOX_ALLOWED_DOMAINS \
     -e SOLVE_MODEL="$MODEL" \
     "$IMAGE" \
-    bash -c 'exec bash "$HOME/vigilant-broccoli/infrastructure/agent-sandbox/solve-todo-runner.sh" --prompt "$1"' _ "$PROMPT"
-  exit $?
+    bash -c 'exec bash "$HOME/vigilant-broccoli/infrastructure/agent-sandbox/solve-todo-runner.sh" --prompt "$1"' _ "$PROMPT" \
+    2>&1 | tee "$LOG_FILE"
+  exit "${PIPESTATUS[0]}"
 fi
 
 LOG_DIR=$(mktemp -d /tmp/vb-solve.XXXXXX)


### PR DESCRIPTION
## Summary

- `solve-todo-runner.sh`: register an `EXIT` trap right after the working branch is created. On any non-zero exit (transient API error, pre-commit failure, etc.) it checks for uncommitted changes, and if present commits them (`--no-verify`, since a WIP salvage shouldn't be blocked by lint/hooks), pushes the branch, and opens a **draft PR** titled `[WIP] ... (agent run incomplete)` pointing at `pnpm agentic:pr:update <PR#> "..."` to continue the work. No-ops on success or when there's nothing uncommitted to salvage.
- `solve-todo.sh`: the free-text `--prompt` path now tees its container output to `$LOG_DIR/solve-prompt.log`, matching the `--id` batch path's logging convention, so failure context survives even if terminal scrollback doesn't.

## Test plan

- [x] `bash -n` on both scripts
- [ ] Trigger a real `solve-todo.sh --prompt "..."` run that fails mid-task (e.g. simulate a transient API error) and confirm a draft PR with the partial diff is opened
- [ ] Confirm a successful run still produces exactly one (non-draft) PR, with no salvage PR alongside it

🤖 Generated with [Claude Code](https://claude.com/claude-code)