### PR TITLE
feat(vb-manager-next-mobile): Lock the app to the owner and add streaming voice transcription

### DIFF
--- a/projects/nx-workspace/apps/vb-manager-next-mobile/libs/api-auth.ts
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/libs/api-auth.ts
@@ -5,10 +5,12 @@ import {
   BEARER_PREFIX,
   GOOGLE_TOKEN_HEADER,
 } from '@vigilant-broccoli/common-js';
+import { isAllowedEmail } from './auth-policy';
 
 const ERROR_MISSING_BEARER = 'Missing bearer token';
 const ERROR_INVALID_SESSION = 'Invalid session';
 const ERROR_MISSING_GOOGLE_TOKEN = 'Missing google token';
+const ERROR_FORBIDDEN = 'Forbidden';
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL as string,
@@ -17,6 +19,9 @@ const supabase = createClient(
 
 const unauthorized = (message: string) =>
   NextResponse.json({ error: message }, { status: 401 });
+
+const forbidden = (message: string) =>
+  NextResponse.json({ error: message }, { status: 403 });
 
 export const requireAuth = async (
   request: NextRequest,
@@ -33,6 +38,7 @@ export const requireAuth = async (
   } = await supabase.auth.getUser(authHeader.slice(BEARER_PREFIX.length));
 
   if (error || !user) return unauthorized(ERROR_INVALID_SESSION);
+  if (!isAllowedEmail(user.email)) return forbidden(ERROR_FORBIDDEN);
 
   const googleToken = request.headers.get(GOOGLE_TOKEN_HEADER);
   if (options?.requireGoogleToken && !googleToken) {

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/libs/auth-policy.ts
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/libs/auth-policy.ts
@@ -1,0 +1,4 @@
+export const ALLOWED_EMAIL = 'harryliu1995@gmail.com';
+
+export const isAllowedEmail = (email: string | null | undefined): boolean =>
+  email?.toLowerCase() === ALLOWED_EMAIL;

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/calendar-input.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/calendar-input.tsx
@@ -12,7 +12,7 @@ import {
   buildAuthHeaders,
   signOutDueToExpiredToken,
 } from '../providers/auth-provider';
-import { useVoiceRecorder } from '../hooks/use-voice-recorder';
+import { useVoiceInput } from '../hooks/use-voice-input';
 
 interface ImagePreview {
   data: string;
@@ -35,10 +35,10 @@ export const CalendarInput = () => {
   const [eventStates, setEventStates] = useState<EventState[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
-  const { recordingState, voiceError, toggleRecording } = useVoiceRecorder(
-    transcript =>
+  const { recordingState, voiceError, interimTranscript, toggleRecording } =
+    useVoiceInput(transcript =>
       setText(prev => (prev ? `${prev}\n${transcript}` : transcript)),
-  );
+    );
 
   const addImageFile = async (file: File) => {
     const { base64, mimeType, previewUrl } = await resizeImage(file);
@@ -252,6 +252,11 @@ export const CalendarInput = () => {
               : 'Voice'}
         </button>
       </div>
+
+      {recordingState === 'recording' && interimTranscript && (
+        <p className="text-sm text-gray-400 italic px-1">{interimTranscript}</p>
+      )}
+
       <button
         onClick={handleParse}
         disabled={!canParse}

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/tasks-input.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/tasks-input.tsx
@@ -7,7 +7,7 @@ import {
   signOutDueToExpiredToken,
 } from '../providers/auth-provider';
 import { GOOGLE_TOKEN_EXPIRED } from '../../../libs/api-errors';
-import { useVoiceRecorder } from '../hooks/use-voice-recorder';
+import { useVoiceInput } from '../hooks/use-voice-input';
 import { resizeImage } from '../utils/image.utils';
 
 type Phase = 'input' | 'analyzing' | 'preview' | 'creating' | 'done';
@@ -37,10 +37,10 @@ export const TasksInput = () => {
   const cameraInputRef = useRef<HTMLInputElement>(null);
 
   const [googleToken, setGoogleToken] = useState<string | null>(null);
-  const { recordingState, voiceError, toggleRecording } = useVoiceRecorder(
-    transcript =>
+  const { recordingState, voiceError, interimTranscript, toggleRecording } =
+    useVoiceInput(transcript =>
       setTextInput(prev => (prev ? `${prev}\n${transcript}` : transcript)),
-  );
+    );
 
   useEffect(() => {
     const token = getGoogleToken();
@@ -290,6 +290,13 @@ export const TasksInput = () => {
                   : 'Voice'}
             </button>
           </div>
+
+          {recordingState === 'recording' && interimTranscript && (
+            <p className="text-sm text-gray-400 italic px-1">
+              {interimTranscript}
+            </p>
+          )}
+
           <button
             onClick={handleParse}
             disabled={!textInput.trim() && !images.length}

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/hooks/use-streaming-speech.ts
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/hooks/use-streaming-speech.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const SPEECH_LANG = 'en-US';
+const ERROR_NO_SPEECH = 'no-speech';
+const ERROR_ABORTED = 'aborted';
+const ERROR_START = 'Failed to start speech recognition';
+const ERROR_RECOGNITION_PREFIX = 'Speech recognition error: ';
+
+type RecordingState = 'idle' | 'recording' | 'transcribing';
+
+const getSpeechRecognition = () =>
+  typeof window === 'undefined'
+    ? null
+    : window.SpeechRecognition || window.webkitSpeechRecognition || null;
+
+export const useStreamingSpeech = (onTranscript: (text: string) => void) => {
+  const [recordingState, setRecordingState] = useState<RecordingState>('idle');
+  const [interimTranscript, setInterimTranscript] = useState('');
+  const [voiceError, setVoiceError] = useState<string | null>(null);
+
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const onTranscriptRef = useRef(onTranscript);
+  const supported = getSpeechRecognition() !== null;
+
+  useEffect(() => {
+    onTranscriptRef.current = onTranscript;
+  }, [onTranscript]);
+
+  useEffect(() => {
+    const SpeechRecognitionCtor = getSpeechRecognition();
+    if (!SpeechRecognitionCtor) return;
+
+    const recognition = new SpeechRecognitionCtor();
+    recognition.continuous = true;
+    recognition.interimResults = true;
+    recognition.lang = SPEECH_LANG;
+
+    recognition.onresult = event => {
+      let interim = '';
+      let finalText = '';
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const segment = event.results[i][0].transcript;
+        if (event.results[i].isFinal) finalText += segment;
+        else interim += segment;
+      }
+      if (finalText.trim()) onTranscriptRef.current(finalText.trim());
+      setInterimTranscript(interim.trim());
+    };
+
+    recognition.onerror = event => {
+      if (event.error === ERROR_NO_SPEECH || event.error === ERROR_ABORTED)
+        return;
+      setVoiceError(`${ERROR_RECOGNITION_PREFIX}${event.error}`);
+      setRecordingState('idle');
+    };
+
+    recognition.onend = () => {
+      setInterimTranscript('');
+      setRecordingState('idle');
+    };
+
+    recognitionRef.current = recognition;
+    return () => recognition.stop();
+  }, []);
+
+  const toggleRecording = useCallback(() => {
+    const recognition = recognitionRef.current;
+    if (!recognition) return;
+
+    if (recordingState === 'recording') {
+      recognition.stop();
+      setRecordingState('idle');
+      return;
+    }
+
+    setVoiceError(null);
+    setInterimTranscript('');
+    try {
+      recognition.start();
+      setRecordingState('recording');
+    } catch {
+      setVoiceError(ERROR_START);
+    }
+  }, [recordingState]);
+
+  return {
+    recordingState,
+    interimTranscript,
+    voiceError,
+    toggleRecording,
+    supported,
+  };
+};

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/hooks/use-voice-input.ts
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/hooks/use-voice-input.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useVoiceRecorder } from './use-voice-recorder';
+import { useStreamingSpeech } from './use-streaming-speech';
+
+export const useVoiceInput = (onTranscript: (text: string) => void) => {
+  const streaming = useStreamingSpeech(onTranscript);
+  const recorder = useVoiceRecorder(onTranscript);
+
+  if (streaming.supported) {
+    const { supported: _supported, ...rest } = streaming;
+    return rest;
+  }
+
+  return { ...recorder, interimTranscript: '' };
+};

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/providers/auth-provider.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/providers/auth-provider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { Session } from '@supabase/supabase-js';
 import { supabase } from '../../../libs/supabase';
+import { isAllowedEmail } from '../../../libs/auth-policy';
 import {
   AUTHORIZATION_HEADER,
   BEARER_PREFIX,
@@ -54,7 +55,17 @@ export default function AuthProvider({
   const [session, setSession] = useState<Session | null | undefined>(undefined);
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    const applySession = (next: Session | null) => {
+      if (next && !isAllowedEmail(next.user.email)) {
+        localStorage.removeItem(GOOGLE_TOKEN_KEY);
+        supabase.auth.signOut();
+        setSession(null);
+        return;
+      }
+      setSession(next);
+    };
+
+    supabase.auth.getSession().then(({ data }) => applySession(data.session));
 
     const {
       data: { subscription },
@@ -62,7 +73,7 @@ export default function AuthProvider({
       if (session?.provider_token) {
         localStorage.setItem(GOOGLE_TOKEN_KEY, session.provider_token);
       }
-      setSession(session);
+      applySession(session);
     });
 
     return () => subscription.unsubscribe();

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/types/speech-recognition.d.ts
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/types/speech-recognition.d.ts
@@ -1,0 +1,47 @@
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  onresult: (event: SpeechRecognitionEvent) => void;
+  onerror: (event: SpeechRecognitionErrorEvent) => void;
+  onend: () => void;
+  start: () => void;
+  stop: () => void;
+}
+
+interface SpeechRecognitionEvent {
+  resultIndex: number;
+  results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionResultList {
+  length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionResult {
+  isFinal: boolean;
+  length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionAlternative {
+  transcript: string;
+  confidence: number;
+}
+
+interface SpeechRecognitionErrorEvent {
+  error: string;
+  message: string;
+}
+
+interface Window {
+  SpeechRecognition: {
+    new (): SpeechRecognition;
+  };
+  webkitSpeechRecognition: {
+    new (): SpeechRecognition;
+  };
+}


### PR DESCRIPTION
## Summary
- Lock every mobile API route to the owner's email (`harryliu1995@gmail.com`): `requireAuth` now returns **403** for any valid Supabase session whose email isn't allowed, so the personal calendar/tasks data can't be reached by another Google account. A shared `libs/auth-policy.ts` (`ALLOWED_EMAIL` + `isAllowedEmail`) is the single source of truth.
- Sign non-owners out client-side in `auth-provider.tsx` so they can't sit on the app shell after completing Google OAuth.
- Port **Speech to Text (Streaming)** from the vb-manager-next feature sandbox: `use-streaming-speech.ts` drives live Web Speech API transcription (interim + finalized results) with the Web Speech API type declarations.
- `use-voice-input.ts` prefers streaming and gracefully falls back to the existing record-and-upload `/api/transcribe` path when the browser lacks Web Speech API support (iOS reliability).
- The existing **Voice** button in `calendar-input.tsx` and `tasks-input.tsx` now shows a live interim transcript preview while recording.

## Test plan
- [ ] Sign in as `harryliu1995@gmail.com` — calendar/tasks load and all actions work.
- [ ] Sign in as any other Google account — bounced to `/login`; API routes return 403.
- [ ] On a Web Speech API browser (Chrome), tap **Voice** — words appear live as interim text and finalized text is appended to the input.
- [ ] On a browser without Web Speech API — **Voice** falls back to record → `/api/transcribe` and still transcribes.
- [ ] `nx lint vb-manager-next-mobile` and prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)