### PR TITLE
feat(vb-manager-next-mobile): Add a dedicated voice transcription page

### DIFF
--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/bottom-nav.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/bottom-nav.tsx
@@ -61,6 +61,25 @@ const NAV_ITEMS = [
       </svg>
     ),
   },
+  {
+    href: '/transcribe',
+    label: 'Transcribe',
+    icon: (
+      <svg
+        className="w-6 h-6"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.75}
+          d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"
+        />
+      </svg>
+    ),
+  },
 ];
 
 export const BottomNav = () => {

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/calendar-input.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/calendar-input.tsx
@@ -12,7 +12,7 @@ import {
   buildAuthHeaders,
   signOutDueToExpiredToken,
 } from '../providers/auth-provider';
-import { useVoiceInput } from '../hooks/use-voice-input';
+import { useVoiceRecorder } from '../hooks/use-voice-recorder';
 
 interface ImagePreview {
   data: string;
@@ -35,10 +35,10 @@ export const CalendarInput = () => {
   const [eventStates, setEventStates] = useState<EventState[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
-  const { recordingState, voiceError, interimTranscript, toggleRecording } =
-    useVoiceInput(transcript =>
+  const { recordingState, voiceError, toggleRecording } = useVoiceRecorder(
+    transcript =>
       setText(prev => (prev ? `${prev}\n${transcript}` : transcript)),
-    );
+  );
 
   const addImageFile = async (file: File) => {
     const { base64, mimeType, previewUrl } = await resizeImage(file);
@@ -252,11 +252,6 @@ export const CalendarInput = () => {
               : 'Voice'}
         </button>
       </div>
-
-      {recordingState === 'recording' && interimTranscript && (
-        <p className="text-sm text-gray-400 italic px-1">{interimTranscript}</p>
-      )}
-
       <button
         onClick={handleParse}
         disabled={!canParse}

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/tasks-input.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/tasks-input.tsx
@@ -7,7 +7,7 @@ import {
   signOutDueToExpiredToken,
 } from '../providers/auth-provider';
 import { GOOGLE_TOKEN_EXPIRED } from '../../../libs/api-errors';
-import { useVoiceInput } from '../hooks/use-voice-input';
+import { useVoiceRecorder } from '../hooks/use-voice-recorder';
 import { resizeImage } from '../utils/image.utils';
 
 type Phase = 'input' | 'analyzing' | 'preview' | 'creating' | 'done';
@@ -37,10 +37,10 @@ export const TasksInput = () => {
   const cameraInputRef = useRef<HTMLInputElement>(null);
 
   const [googleToken, setGoogleToken] = useState<string | null>(null);
-  const { recordingState, voiceError, interimTranscript, toggleRecording } =
-    useVoiceInput(transcript =>
+  const { recordingState, voiceError, toggleRecording } = useVoiceRecorder(
+    transcript =>
       setTextInput(prev => (prev ? `${prev}\n${transcript}` : transcript)),
-    );
+  );
 
   useEffect(() => {
     const token = getGoogleToken();
@@ -290,13 +290,6 @@ export const TasksInput = () => {
                   : 'Voice'}
             </button>
           </div>
-
-          {recordingState === 'recording' && interimTranscript && (
-            <p className="text-sm text-gray-400 italic px-1">
-              {interimTranscript}
-            </p>
-          )}
-
           <button
             onClick={handleParse}
             disabled={!textInput.trim() && !images.length}

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/voice-transcriber.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/voice-transcriber.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+import { useVoiceInput } from '../hooks/use-voice-input';
+
+const PLACEHOLDER =
+  'Tap the mic and start speaking — your transcript appears here...';
+const LABEL_RECORD = 'Record';
+const LABEL_STOP = 'Stop';
+const LABEL_TRANSCRIBING = 'Transcribing...';
+const LABEL_CLEAR = 'Clear';
+const COPY_IDLE = 'Copy';
+const COPY_DONE = 'Copied!';
+const COPY_RESET_MS = 2000;
+
+export const VoiceTranscriber = () => {
+  const [transcript, setTranscript] = useState('');
+  const [copyLabel, setCopyLabel] = useState(COPY_IDLE);
+
+  const { recordingState, voiceError, interimTranscript, toggleRecording } =
+    useVoiceInput(text =>
+      setTranscript(prev => (prev ? `${prev} ${text}` : text)),
+    );
+
+  const isRecording = recordingState === 'recording';
+  const isTranscribing = recordingState === 'transcribing';
+  const hasText = transcript.trim().length > 0;
+
+  const handleCopy = async () => {
+    if (!hasText || !navigator.clipboard) return;
+    await navigator.clipboard.writeText(transcript.trim());
+    setCopyLabel(COPY_DONE);
+    setTimeout(() => setCopyLabel(COPY_IDLE), COPY_RESET_MS);
+  };
+
+  const recordLabel = isRecording
+    ? LABEL_STOP
+    : isTranscribing
+      ? LABEL_TRANSCRIBING
+      : LABEL_RECORD;
+
+  return (
+    <div className="space-y-4">
+      <textarea
+        value={transcript}
+        onChange={e => setTranscript(e.target.value)}
+        placeholder={PLACEHOLDER}
+        rows={10}
+        className="w-full border border-gray-200 rounded-xl px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-300 resize-none bg-white"
+      />
+
+      {isRecording && interimTranscript && (
+        <p className="text-sm text-gray-400 italic px-1">{interimTranscript}</p>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          onClick={toggleRecording}
+          disabled={isTranscribing}
+          className={`flex-[2] flex items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium text-white transition-colors disabled:opacity-50 ${
+            isRecording
+              ? 'bg-red-500 hover:bg-red-600 active:bg-red-700'
+              : 'bg-blue-500 hover:bg-blue-600 active:bg-blue-700'
+          }`}
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 11a7 7 0 01-7 7m0 0a7 7 0 01-7-7m7 7v4m0 0H8m4 0h4m-4-8a3 3 0 01-3-3V5a3 3 0 116 0v6a3 3 0 01-3 3z"
+            />
+          </svg>
+          {recordLabel}
+        </button>
+        <button
+          onClick={handleCopy}
+          disabled={!hasText}
+          className="flex-1 border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-600 hover:bg-gray-50 active:bg-gray-100 disabled:opacity-50 transition-colors"
+        >
+          {copyLabel}
+        </button>
+        <button
+          onClick={() => setTranscript('')}
+          disabled={!hasText}
+          className="flex-1 border border-gray-200 rounded-lg px-3 py-2.5 text-sm text-gray-600 hover:bg-gray-50 active:bg-gray-100 disabled:opacity-50 transition-colors"
+        >
+          {LABEL_CLEAR}
+        </button>
+      </div>
+
+      {voiceError && (
+        <p className="text-sm text-red-600 bg-red-50 rounded-lg px-3 py-2">
+          {voiceError}
+        </p>
+      )}
+    </div>
+  );
+};

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/transcribe/page.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/transcribe/page.tsx
@@ -1,0 +1,20 @@
+import { VoiceTranscriber } from '../components/voice-transcriber';
+import { ProtectedRoute } from '../components/protected-route';
+
+export default function TranscribePage() {
+  return (
+    <ProtectedRoute>
+      <main className="min-h-screen bg-gray-50">
+        <header className="bg-white border-b border-gray-100 px-4 py-4 safe-top">
+          <h1 className="text-lg font-semibold text-gray-800">Transcribe</h1>
+          <p className="text-xs text-gray-500 mt-0.5">
+            Record speech, then copy the text
+          </p>
+        </header>
+        <div className="px-4 py-5 pb-24">
+          <VoiceTranscriber />
+        </div>
+      </main>
+    </ProtectedRoute>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a standalone **Transcribe** page (`/transcribe`) where the user dictates and the streaming transcript accumulates in an editable textarea, with **Copy** and **Clear** actions — the intended UX for #331, which had wired streaming into the Calendar/Tasks voice buttons instead.
- Restore the original record-then-transcribe voice behavior on `calendar-input` and `tasks-input` (revert them to their pre-#331 `useVoiceRecorder` usage).
- New `voice-transcriber.tsx` component uses the existing `useVoiceInput` hook (live Web Speech API streaming with a graceful fallback to server transcription) and shows a live interim preview while recording.
- Add a **Transcribe** tab (mic icon) to the bottom navigation.

## Test plan
- [ ] Open the **Transcribe** tab; tap **Record** and speak — interim words show live, finalized text appends to the textarea.
- [ ] Tap **Copy** — clipboard contains the transcript; button briefly shows "Copied!".
- [ ] Tap **Clear** — textarea empties; Copy/Clear disable when empty.
- [ ] On a browser without Web Speech API, **Record** falls back to record → `/api/transcribe` and still yields copyable text.
- [ ] Calendar and Tasks voice buttons behave exactly as before #331 (record → transcribe on stop).
- [ ] `nx lint vb-manager-next-mobile` and prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)