### PR TITLE
fix(vb-manager-next-mobile): Fall back to server transcription on streaming speech network error

### DIFF
--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/hooks/use-streaming-speech.ts
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/hooks/use-streaming-speech.ts
@@ -5,6 +5,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 const SPEECH_LANG = 'en-US';
 const ERROR_NO_SPEECH = 'no-speech';
 const ERROR_ABORTED = 'aborted';
+const ERROR_NETWORK = 'network';
+const ERROR_SERVICE_NOT_ALLOWED = 'service-not-allowed';
 const ERROR_START = 'Failed to start speech recognition';
 const ERROR_RECOGNITION_PREFIX = 'Speech recognition error: ';
 
@@ -19,6 +21,7 @@ export const useStreamingSpeech = (onTranscript: (text: string) => void) => {
   const [recordingState, setRecordingState] = useState<RecordingState>('idle');
   const [interimTranscript, setInterimTranscript] = useState('');
   const [voiceError, setVoiceError] = useState<string | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
 
   const recognitionRef = useRef<SpeechRecognition | null>(null);
   const onTranscriptRef = useRef(onTranscript);
@@ -52,6 +55,14 @@ export const useStreamingSpeech = (onTranscript: (text: string) => void) => {
     recognition.onerror = event => {
       if (event.error === ERROR_NO_SPEECH || event.error === ERROR_ABORTED)
         return;
+      if (
+        event.error === ERROR_NETWORK ||
+        event.error === ERROR_SERVICE_NOT_ALLOWED
+      ) {
+        setUnavailable(true);
+        setRecordingState('idle');
+        return;
+      }
       setVoiceError(`${ERROR_RECOGNITION_PREFIX}${event.error}`);
       setRecordingState('idle');
     };
@@ -91,5 +102,6 @@ export const useStreamingSpeech = (onTranscript: (text: string) => void) => {
     voiceError,
     toggleRecording,
     supported,
+    unavailable,
   };
 };

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/hooks/use-voice-input.ts
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/hooks/use-voice-input.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import { useVoiceRecorder } from './use-voice-recorder';
 import { useStreamingSpeech } from './use-streaming-speech';
 
@@ -7,10 +8,28 @@ export const useVoiceInput = (onTranscript: (text: string) => void) => {
   const streaming = useStreamingSpeech(onTranscript);
   const recorder = useVoiceRecorder(onTranscript);
 
-  if (streaming.supported) {
-    const { supported: _supported, ...rest } = streaming;
-    return rest;
+  const startRecorderRef = useRef(recorder.toggleRecording);
+  const handedOffRef = useRef(false);
+
+  useEffect(() => {
+    startRecorderRef.current = recorder.toggleRecording;
+  });
+
+  useEffect(() => {
+    if (streaming.unavailable && !handedOffRef.current) {
+      handedOffRef.current = true;
+      startRecorderRef.current();
+    }
+  }, [streaming.unavailable]);
+
+  if (!streaming.supported || streaming.unavailable) {
+    return { ...recorder, interimTranscript: '' };
   }
 
-  return { ...recorder, interimTranscript: '' };
+  const {
+    supported: _supported,
+    unavailable: _unavailable,
+    ...rest
+  } = streaming;
+  return rest;
 };


### PR DESCRIPTION
## Summary
- Fixes **"Speech recognition error: network"** on the deployed app. The streaming Web Speech API routes audio to the browser vendor's cloud service, which is unreachable on iOS and behind ad/tracker blockers, VPNs, and privacy browsers (Brave) — surfacing as a `network` error.
- The prior fallback in `use-voice-input.ts` only engaged when the API was **absent** (`supported === false`); a **runtime** `network` failure left the user with a dead error and no recovery.
- `use-streaming-speech.ts` now treats `network` / `service-not-allowed` as **streaming unavailable** (new `unavailable` flag) rather than a hard error.
- `use-voice-input.ts` switches to the existing MediaRecorder → `/api/transcribe` server path when streaming is unsupported **or** becomes unavailable, and hands the in-progress tap off to the recorder so the user's recording continues seamlessly instead of failing.

## Notes
- Independent of PR #332 (touches only the two hooks; no overlap with the transcribe-page changes). Applies to both the current Calendar/Tasks voice buttons and the upcoming `/transcribe` page.
- No new cloud service introduced; `/api/transcribe` already exists and is deployed.

## Test plan
- [ ] On iOS / a browser where streaming fails (or with the speech endpoint blocked), tap the mic — instead of "Speech recognition error: network", recording continues via the server path and transcribes on stop.
- [ ] On desktop Chrome (streaming works), behavior is unchanged: live interim + finalized transcript.
- [ ] On a browser with no Web Speech API at all, still falls back to server transcription (unchanged).
- [ ] `nx lint vb-manager-next-mobile` and prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)