### PR TITLE
feat(vb-manager-next-mobile): Add a sign-out button

### DIFF
--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/sign-out-button.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/sign-out-button.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useAuth, signOut } from '../providers/auth-provider';
+
+export const SignOutButton = () => {
+  const pathname = usePathname();
+  const session = useAuth();
+
+  if (pathname === '/login' || !session) return null;
+
+  return (
+    <button
+      onClick={() => signOut()}
+      aria-label="Sign out"
+      className="fixed top-3 right-3 z-20 safe-top flex items-center gap-1.5 rounded-lg border border-gray-200 bg-white/80 px-3 py-1.5 text-xs font-medium text-gray-600 backdrop-blur hover:bg-gray-50 active:bg-gray-100 transition-colors"
+    >
+      <svg
+        className="w-4 h-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.75}
+          d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+        />
+      </svg>
+      Sign out
+    </button>
+  );
+};

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/layout.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './global.css';
 import AuthProvider from './providers/auth-provider';
 import { BottomNav } from './components/bottom-nav';
+import { SignOutButton } from './components/sign-out-button';
 
 export const metadata = {
   title: 'VB Manager',
@@ -22,6 +23,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="bg-gray-50">
         <AuthProvider>
+          <SignOutButton />
           {children}
           <BottomNav />
         </AuthProvider>

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/providers/auth-provider.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/providers/auth-provider.tsx
@@ -42,10 +42,12 @@ export const buildAuthHeaders = async (options?: {
   return headers;
 };
 
-export const signOutDueToExpiredToken = async () => {
+export const signOut = async () => {
   localStorage.removeItem(GOOGLE_TOKEN_KEY);
   await supabase.auth.signOut();
 };
+
+export const signOutDueToExpiredToken = signOut;
 
 export default function AuthProvider({
   children,


### PR DESCRIPTION
## Summary
- Add a **Sign out** button so the user can end their session from any screen — notably to recover from an expired Supabase token (the "invalid session" case) instead of waiting for an automatic sign-out.
- New `sign-out-button.tsx` renders globally in the app shell (top-right), self-hiding on `/login` and when signed out — same pattern as `BottomNav`.
- Added a reusable `signOut` helper in `auth-provider.tsx` (clears the Google token + Supabase session); `signOutDueToExpiredToken` now aliases it to avoid duplication. After sign-out, `ProtectedRoute` routes back to `/login`.

## Test plan
- [ ] While signed in, the **Sign out** button appears top-right on Calendar, Tasks, My Tasks, and Transcribe.
- [ ] Tapping it clears the session and redirects to `/login`.
- [ ] The button is hidden on `/login` and before a session loads.
- [ ] Signing back in restores access (fresh token resolves the "invalid session" on voice).
- [ ] `nx lint vb-manager-next-mobile` and prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)