### PR TITLE
feat(vb-manager-next-mobile): Route Calendar and Tasks voice through the streaming→recorder fallback

### DIFF
--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/calendar-input.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/calendar-input.tsx
@@ -12,7 +12,7 @@ import {
   buildAuthHeaders,
   signOutDueToExpiredToken,
 } from '../providers/auth-provider';
-import { useVoiceRecorder } from '../hooks/use-voice-recorder';
+import { useVoiceInput } from '../hooks/use-voice-input';
 
 interface ImagePreview {
   data: string;
@@ -35,10 +35,10 @@ export const CalendarInput = () => {
   const [eventStates, setEventStates] = useState<EventState[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const cameraInputRef = useRef<HTMLInputElement>(null);
-  const { recordingState, voiceError, toggleRecording } = useVoiceRecorder(
-    transcript =>
+  const { recordingState, voiceError, interimTranscript, toggleRecording } =
+    useVoiceInput(transcript =>
       setText(prev => (prev ? `${prev}\n${transcript}` : transcript)),
-  );
+    );
 
   const addImageFile = async (file: File) => {
     const { base64, mimeType, previewUrl } = await resizeImage(file);
@@ -252,6 +252,11 @@ export const CalendarInput = () => {
               : 'Voice'}
         </button>
       </div>
+
+      {recordingState === 'recording' && interimTranscript && (
+        <p className="text-sm text-gray-400 italic px-1">{interimTranscript}</p>
+      )}
+
       <button
         onClick={handleParse}
         disabled={!canParse}

--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/tasks-input.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/components/tasks-input.tsx
@@ -7,7 +7,7 @@ import {
   signOutDueToExpiredToken,
 } from '../providers/auth-provider';
 import { GOOGLE_TOKEN_EXPIRED } from '../../../libs/api-errors';
-import { useVoiceRecorder } from '../hooks/use-voice-recorder';
+import { useVoiceInput } from '../hooks/use-voice-input';
 import { resizeImage } from '../utils/image.utils';
 
 type Phase = 'input' | 'analyzing' | 'preview' | 'creating' | 'done';
@@ -37,10 +37,10 @@ export const TasksInput = () => {
   const cameraInputRef = useRef<HTMLInputElement>(null);
 
   const [googleToken, setGoogleToken] = useState<string | null>(null);
-  const { recordingState, voiceError, toggleRecording } = useVoiceRecorder(
-    transcript =>
+  const { recordingState, voiceError, interimTranscript, toggleRecording } =
+    useVoiceInput(transcript =>
       setTextInput(prev => (prev ? `${prev}\n${transcript}` : transcript)),
-  );
+    );
 
   useEffect(() => {
     const token = getGoogleToken();
@@ -290,6 +290,13 @@ export const TasksInput = () => {
                   : 'Voice'}
             </button>
           </div>
+
+          {recordingState === 'recording' && interimTranscript && (
+            <p className="text-sm text-gray-400 italic px-1">
+              {interimTranscript}
+            </p>
+          )}
+
           <button
             onClick={handleParse}
             disabled={!textInput.trim() && !images.length}


### PR DESCRIPTION
## Summary
- Make **all** voice surfaces consistent: Calendar and Tasks now use `useVoiceInput` (live Web Speech streaming with an automatic fallback to server transcription), matching the Transcribe page. Previously they used `useVoiceRecorder` directly — server-only, no streaming, no runtime fallback.
- Adds a live interim-transcript preview under the buttons while recording on both screens.
- Behavior now everywhere: streaming when supported → on `network`/`service-not-allowed`, seamlessly hand off to MediaRecorder → `/api/transcribe` (the #333 fallback).

## Notes
- Pairs well with PR #334 (sign-out button) for recovering from an expired token; a follow-up could still add proactive token refresh + graceful 401 handling in `useVoiceRecorder`.

## Test plan
- [ ] Calendar & Tasks: tap the mic on a streaming-capable browser — words appear live, finalized text appends to the input.
- [ ] On iOS / a blocked network, the mic seamlessly falls back to record → `/api/transcribe` and still transcribes.
- [ ] Transcribe page behavior unchanged.
- [ ] `nx lint vb-manager-next-mobile` and prettier pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)