### PR TITLE
fix(agent-sandbox): Correct and harden the CI agentic-solve token handling.

### DIFF
--- a/.github/workflows/manual-agentic-solve.yml
+++ b/.github/workflows/manual-agentic-solve.yml
@@ -71,8 +71,12 @@ jobs:
           if [ -n "$PROMPT" ]; then
             bash "$SOLVE" --model "$MODEL" --prompt "$PROMPT" || STATUS=$?
           else
-            # shellcheck disable=SC2086
-            bash "$SOLVE" --model "$MODEL" $IDS || STATUS=$?
+            if ! printf '%s' "$IDS" | grep -qE '^[0-9a-fA-F ]*$'; then
+              echo "ERROR: 'ids' must be space-separated hex TODO ids." >&2
+              exit 1
+            fi
+            read -ra ID_ARR <<<"$IDS"
+            bash "$SOLVE" --model "$MODEL" "${ID_ARR[@]}" || STATUS=$?
           fi
           echo "===== per-id solve logs ====="
           for f in /tmp/vb-solve.*/*.log; do

--- a/infrastructure/agent-sandbox/solve-todo.sh
+++ b/infrastructure/agent-sandbox/solve-todo.sh
@@ -61,6 +61,12 @@ if [ -z "${GH_TOKEN:-}" ]; then
   exit 1
 fi
 
+# The token is minted at runtime, so GitHub Actions' log masker doesn't know it.
+# Register it so it can't leak into job logs (e.g. the per-id logs tee'd by CI).
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  echo "::add-mask::$GH_TOKEN"
+fi
+
 if [ -n "$PROMPT" ]; then
   LOG_DIR=$(mktemp -d /tmp/vb-solve.XXXXXX)
   LOG_FILE="$LOG_DIR/solve-prompt.log"

--- a/infrastructure/agent-sandbox/solve-todo.sh
+++ b/infrastructure/agent-sandbox/solve-todo.sh
@@ -49,6 +49,10 @@ elif [ -n "${AGENT_GH_APP_ID:-}" ] && [ -n "${AGENT_GH_APP_PRIVATE_KEY:-}" ]; th
     *) PEM_CONTENT=$(printf '%s' "$AGENT_GH_APP_PRIVATE_KEY" | base64 -d) ;;
   esac
   GH_TOKEN=$("$SCRIPT_DIR/mint-github-app-token.sh" "$AGENT_GH_APP_ID" <(printf '%s\n' "$PEM_CONTENT"))
+  # export so `docker run -e GH_TOKEN` forwards it into the container (the
+  # load-env-from-vault.sh path above exports it too); without this the sandbox
+  # gets no token and `git push` fails with "could not read Username".
+  export GH_TOKEN
 fi
 
 if [ -z "${GH_TOKEN:-}" ]; then


### PR DESCRIPTION
## Summary

Follow-up to #336, covering the first-run failure and a security pass over the CI path.

**Correctness fix** — the first `manual-agentic-solve` run got all the way through (firewall up, repo cloned, Claude made the change, pre-commit + commit passed) then failed at `git push` with `fatal: could not read Username for 'https://github.com'`. Root cause: `solve-todo.sh`'s CI branch assigned `GH_TOKEN=$(mint...)` without exporting it, so `docker run -e GH_TOKEN` (which forwards from the environment) passed nothing into the container; `entrypoint.sh` then skipped its `credential.helper` setup. Fix: `export GH_TOKEN` after minting (separate statement so `set -e` still fails fast on a mint error).

**Security hardening:**
- Mask the runtime-minted installation token in GitHub Actions. It's generated at runtime, so GitHub's log masker doesn't know it; the workflow tees per-id container logs to the job output, which could otherwise surface it unmasked. `solve-todo.sh` now emits `::add-mask::` for `GH_TOKEN` when running under `$GITHUB_ACTIONS` (no-op locally, and the token stays out of `$GITHUB_ENV`).
- Validate and safely split the `ids` input in the workflow: reject anything outside `^[0-9a-fA-F ]*$`, then `read -ra` into an array and pass `"${ID_ARR[@]}"` instead of an unquoted `$IDS` (removes word-split/glob expansion of dispatcher-controlled input; drops the `# shellcheck disable=SC2086`).

Considered but deliberately **not** done: a "dedicated mint step" to keep the GitHub App private key out of the solve step. `hashicorp/vault-action` already exports the PEM into `$GITHUB_ENV` job-wide, so that restructure wouldn't remove it — and handing a token from a separate step to the solve step would newly route the minted token through `$GITHUB_ENV`, a small *increase* in surface. The PEM is masked, confined to the ephemeral runner, and never passed into the container.

## Test plan

- [ ] Re-dispatch: `gh workflow run manual-agentic-solve.yml -f prompt="add a short comment to the root README" -f model=sonnet` and `gh run watch` — confirm the solve pushes the `agent/…` branch and opens the agent's PR, and that no token appears in the job logs.
- [ ] Dispatch with a real id: `gh workflow run manual-agentic-solve.yml -f ids="<existing TODO id>"`.
- [ ] Dispatch with a bogus id (e.g. `-f ids="*"`) and confirm the job fails fast with the validation error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)