### PR TITLE
fix(vb-manager-next-mobile): Give the notepad a real height so long notes aren't clipped.

### DIFF
--- a/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/notepad/page.tsx
+++ b/projects/nx-workspace/apps/vb-manager-next-mobile/src/app/notepad/page.tsx
@@ -4,15 +4,15 @@ import { ProtectedRoute } from '../components/protected-route';
 export default function NotepadPage() {
   return (
     <ProtectedRoute>
-      <main className="min-h-screen bg-gray-50">
+      <main className="flex flex-col h-screen bg-gray-50">
         <header className="bg-white border-b border-gray-100 px-4 py-4 safe-top">
           <h1 className="text-lg font-semibold text-gray-800">Notepad</h1>
           <p className="text-xs text-gray-500 mt-0.5">
             Synced across your devices
           </p>
         </header>
-        <div className="px-4 py-5 pb-24">
-          <NotepadEditor />
+        <div className="flex flex-1 min-h-0 flex-col px-4 py-5 pb-24">
+          <NotepadEditor style={{ flex: 1 }} />
         </div>
       </main>
     </ProtectedRoute>


### PR DESCRIPTION
## Summary
- The mobile notepad rendered `<NotepadEditor />` with no height, so the shared `SyncedTextEditor` textarea collapsed to its `minHeight: 200px` fallback — making long notes look clipped even though the full content loads from the same Supabase `notepad` row as the desktop app.
- Made the page a full-height flex column (`h-screen`) with a `flex-1 min-h-0` content area and passed `style={{ flex: 1 }}` to the editor, mirroring how the desktop dialog (`height: 80vh` + `flex: 1`) already sizes the same component.
- No component or data changes — mobile and desktop continue to share `SyncedTextEditor` from `@vigilant-broccoli/react-lib`.

## Test plan
- [ ] Open the mobile app `/notepad` page and confirm the textarea fills the screen down to the bottom nav.
- [ ] Verify a long note is fully scrollable/visible rather than capped at ~200px.
- [ ] Confirm content still syncs with vb-manager-next (same note text appears in both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)