### PR TITLE
feat(vb-manager-next): Surface text-tools as a dev-dashboard tab

### DIFF
--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/dev-dashboard/page.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/dev-dashboard/page.tsx
@@ -18,11 +18,13 @@ import { VercelAppsComponent } from '../../components/vercel-apps.component';
 import { LocalServicesComponent } from '../../components/local-services.component';
 import { LanDevicesComponent } from '../../components/lan-devices.component';
 import { OutboundConnectionsComponent } from '../../components/outbound-connections.component';
+import { TextToolsPage } from '../../components/pages/TextToolsPage';
 
 const TAB = {
   LOCAL: 'local',
   CLOUD: 'cloud',
   NETWORK: 'network',
+  TEXT_TOOLS: 'text-tools',
 } as const;
 
 type Tab = (typeof TAB)[keyof typeof TAB];
@@ -58,6 +60,7 @@ export default function Page() {
         <Tabs.Trigger value={TAB.LOCAL}>Local Service</Tabs.Trigger>
         <Tabs.Trigger value={TAB.CLOUD}>Cloud Services</Tabs.Trigger>
         <Tabs.Trigger value={TAB.NETWORK}>Network Tools</Tabs.Trigger>
+        <Tabs.Trigger value={TAB.TEXT_TOOLS}>Text Tools</Tabs.Trigger>
       </Tabs.List>
       <Tabs.Content value={TAB.LOCAL} className="pt-4 flex-1 min-h-0">
         <div className="grid grid-cols-4 gap-4">
@@ -109,6 +112,9 @@ export default function Page() {
             <LocalServicesComponent />
           </div>
         </div>
+      </Tabs.Content>
+      <Tabs.Content value={TAB.TEXT_TOOLS} className="pt-4 flex-1 min-h-0">
+        <TextToolsPage />
       </Tabs.Content>
     </Tabs.Root>
   );

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/text-tools/page.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/text-tools/page.tsx
@@ -1,8 +1,0 @@
-'use client'
-import {TextToolsPage} from '../../components/pages/TextToolsPage'
-
-export default function Page() {
-  return (
-    <TextToolsPage/>
-  );
-}

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/app.const.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/app.const.ts
@@ -32,10 +32,6 @@ export const APP_ROUTE: Record<string, ExtendedNavRoute> = {
     title: 'Event Calendars',
     path: '/event-calendars',
   },
-  TEXT_TOOLS: {
-    title: 'Text Tools',
-    path: '/text-tools',
-  },
   NOTEPAD: {
     title: 'Notepad',
     path: '/notepad',


### PR DESCRIPTION
## Summary
- Add a **Text Tools** tab to the `vb-manager-next` dev-dashboard, rendering the existing `TextToolsPage` component alongside the Local/Cloud/Network tabs.
- Reuses the standalone `/text-tools` page's component so the env-var/JSON/base64/percent-encoding converters and text analysis now live in the dev dashboard's tab container.

## Test plan
- [ ] `npx tsc --noEmit -p apps/ui/vb-manager-next/tsconfig.json` passes
- [ ] Open `/dev-dashboard`, click the **Text Tools** tab, and confirm all conversion forms + character counter render and function
- [ ] Confirm tab selection still persists across reloads via `localStorage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)