### PR TITLE
feat(vb-manager-next): Move API Keys into a dev-dashboard tab

### DIFF
--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/api-keys/page.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/api-keys/page.tsx
@@ -1,7 +1,0 @@
-'use client';
-
-import { ApiKeysComponent } from '../../components/api-keys.component';
-
-export default function Page() {
-  return <ApiKeysComponent />;
-}

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/dev-dashboard/page.tsx
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/(pages)/dev-dashboard/page.tsx
@@ -19,12 +19,14 @@ import { LocalServicesComponent } from '../../components/local-services.componen
 import { LanDevicesComponent } from '../../components/lan-devices.component';
 import { OutboundConnectionsComponent } from '../../components/outbound-connections.component';
 import { TextToolsPage } from '../../components/pages/TextToolsPage';
+import { ApiKeysComponent } from '../../components/api-keys.component';
 
 const TAB = {
   LOCAL: 'local',
   CLOUD: 'cloud',
   NETWORK: 'network',
   TEXT_TOOLS: 'text-tools',
+  API_KEYS: 'api-keys',
 } as const;
 
 type Tab = (typeof TAB)[keyof typeof TAB];
@@ -61,6 +63,7 @@ export default function Page() {
         <Tabs.Trigger value={TAB.CLOUD}>Cloud Services</Tabs.Trigger>
         <Tabs.Trigger value={TAB.NETWORK}>Network Tools</Tabs.Trigger>
         <Tabs.Trigger value={TAB.TEXT_TOOLS}>Text Tools</Tabs.Trigger>
+        <Tabs.Trigger value={TAB.API_KEYS}>API Keys</Tabs.Trigger>
       </Tabs.List>
       <Tabs.Content value={TAB.LOCAL} className="pt-4 flex-1 min-h-0">
         <div className="grid grid-cols-4 gap-4">
@@ -115,6 +118,9 @@ export default function Page() {
       </Tabs.Content>
       <Tabs.Content value={TAB.TEXT_TOOLS} className="pt-4 flex-1 min-h-0">
         <TextToolsPage />
+      </Tabs.Content>
+      <Tabs.Content value={TAB.API_KEYS} className="pt-4 flex-1 min-h-0">
+        <ApiKeysComponent />
       </Tabs.Content>
     </Tabs.Root>
   );

--- a/projects/nx-workspace/apps/ui/vb-manager-next/src/app/app.const.ts
+++ b/projects/nx-workspace/apps/ui/vb-manager-next/src/app/app.const.ts
@@ -24,10 +24,6 @@ export const APP_ROUTE: Record<string, ExtendedNavRoute> = {
     title: 'Dev Dashboard',
     path: '/dev-dashboard',
   },
-  API_KEYS: {
-    title: 'API Keys',
-    path: '/api-keys',
-  },
   EVENT_CALENDARS: {
     title: 'Event Calendars',
     path: '/event-calendars',


### PR DESCRIPTION
## Summary
- Add an **API Keys** tab to the `vb-manager-next` dev-dashboard, rendering the existing `ApiKeysComponent` alongside the Local/Cloud/Network/Text Tools tabs.
- Remove the standalone `/api-keys` route and its navbar entry now that the manager lives in the dev-dashboard tab container (mirrors the earlier text-tools change).

## Test plan
- [ ] `npx tsc --noEmit -p apps/ui/vb-manager-next/tsconfig.json` passes
- [ ] Open `/dev-dashboard`, click the **API Keys** tab, and confirm the API keys list/create/delete flows render and function
- [ ] Confirm the `/api-keys` route and navbar link are gone and tab selection still persists across reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)