### PR TITLE
chore: Add deploy:local-services script

### DIFF
--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -95,6 +95,7 @@ Useful infra-level CLI commands, runnable via `pnpm run <script>`.
   vb-manager-next:delete      Delete vb-manager-next PM2 process
   vb-manager-next:logs        Tail vb-manager-next PM2 logs
   vb-manager-next:status      Show PM2 process status
+  deploy:local-services       Bring up local Docker services + reload vb-manager-next
   health-check                Run health check script
 
 🤖 AGENTIC — DEV SANDBOX (attended; you drive the persistent container)

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "vb-manager-next:delete": "cd projects/nx-workspace && nx run vb-manager-next:pm2:delete",
     "vb-manager-next:logs": "cd projects/nx-workspace && nx run vb-manager-next:pm2:logs",
     "vb-manager-next:status": "cd projects/nx-workspace && nx run vb-manager-next:pm2:status",
+    "deploy:local-services": "pnpm local:docker:up && pnpm vb-manager-next:reload",
     "homelab:up": "docker compose -f infrastructure/homelab/docker-compose.yml up -d && tailscale serve --bg --tcp=80 tcp://127.0.0.1:22100",
     "homelab:down": "tailscale serve --tcp=80 off; docker compose -f infrastructure/homelab/docker-compose.yml down",
     "homelab:restart": "docker compose -f infrastructure/homelab/docker-compose.yml restart",


### PR DESCRIPTION
## Summary
- Add a `deploy:local-services` root script that brings up local Docker Compose services then reloads `vb-manager-next` via PM2 (`pnpm local:docker:up && pnpm vb-manager-next:reload`).
- Document it in the LOCAL section of `docs/cheatsheet.md`.

## Test plan
- [ ] `pnpm deploy:local-services` starts the local Docker containers and reloads the `vb-manager-next` PM2 process.
- [ ] `pnpm cheatsheet` lists `deploy:local-services`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)